### PR TITLE
[Feat] 리뷰 생성 시 isbn 기반 도서 자동 저장 및 BookConverter 폴더 정리 (#41)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/converter/BookConverter.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/converter/BookConverter.java
@@ -1,0 +1,67 @@
+package com.bookspace.domain.book.converter;
+
+import com.bookspace.domain.book.dto.AladinItemResponseDto;
+import com.bookspace.domain.book.dto.BookSearchResponseDto;
+import com.bookspace.domain.book.vo.BookVo;
+
+
+public final class BookConverter {
+
+    // 유틸 클래스 -> 인스턴스 생성 방지
+    private BookConverter() {}
+
+    /**
+     * 알라딘 API 응답 -> DB 저장용 BookVo
+     */
+    public static BookVo toBookVoFromAladinItem(AladinItemResponseDto item) {
+        if (item == null) return null;
+
+        BookVo vo = new BookVo();
+        vo.setBookTitle(item.getTitle());
+        vo.setBookAuthor(item.getAuthor());
+        vo.setBookPublisher(item.getPublisher());
+        vo.setBookPublicationDate(item.getPubDate());
+        vo.setBookIsbn(item.getIsbn13());
+        vo.setBookDescription(item.getDescription());
+        vo.setBookPrice(item.getPriceStandard());
+        vo.setBookImageUrl(item.getCover());
+        vo.setBookSalesPoint(item.getSalesPoint());
+        vo.setBookCategory(item.getCategoryName());
+        return vo;
+    }
+
+    /**
+     * DB에서 조회한 BookVo -> 검색 응답 DTO
+     */
+    public static BookSearchResponseDto toSearchResponseFromBookVo(BookVo vo) {
+        if (vo == null) return null;
+
+        BookSearchResponseDto dto = new BookSearchResponseDto();
+        dto.setTitle(vo.getBookTitle());
+        dto.setAuthor(vo.getBookAuthor());
+        dto.setPublisher(vo.getBookPublisher());
+        dto.setPubDate(vo.getBookPublicationDate());
+        dto.setIsbn13(vo.getBookIsbn());
+        dto.setCover(vo.getBookImageUrl());
+        dto.setCategoryName(vo.getBookCategory());
+        return dto;
+    }
+
+    /**
+     * 알라딘 검색 결과 DTO -> 검색 응답 DTO
+     * (DB에 저장하지 않고 바로 검색 결과로 내려줄 때)
+     */
+    public static BookSearchResponseDto toSearchResponseFromAladinItem(AladinItemResponseDto item) {
+        if (item == null) return null;
+
+        BookSearchResponseDto dto = new BookSearchResponseDto();
+        dto.setTitle(item.getTitle());
+        dto.setAuthor(item.getAuthor());
+        dto.setPublisher(item.getPublisher());
+        dto.setPubDate(item.getPubDate());
+        dto.setIsbn13(item.getIsbn13());
+        dto.setCover(item.getCover());
+        dto.setCategoryName(item.getCategoryName());
+        return dto;
+    }
+}

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
@@ -9,7 +9,10 @@ import com.bookspace.domain.book.vo.BookVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.bookspace.domain.book.converter.BookConverter;
 
+
+import java.awt.print.Book;
 import java.util.List;
 
 @Service
@@ -41,7 +44,7 @@ public class BookServiceImpl implements BookService {
             return List.of();
         }
 
-        return dbResponse.stream().map(this::toSearchDto).toList(); // BookVo -> BookSearchResponseDto
+        return dbResponse.stream().map(BookConverter::toSearchResponseFromBookVo).toList(); // BookVo -> BookSearchResponseDto
     }
 
     // [검색] 알라딘 api
@@ -52,7 +55,7 @@ public class BookServiceImpl implements BookService {
             return List.of();
         }
 
-        return apiResponse.getItems().stream().map(this::toSearchDto).toList();
+        return apiResponse.getItems().stream().map(BookConverter::toSearchResponseFromAladinItem).toList();
     }
 
 
@@ -84,7 +87,7 @@ public class BookServiceImpl implements BookService {
 
         AladinItemResponseDto item = apiResponse.getItems().get(0);
 
-        BookVo newBookVo = toBookVo(item); // 알라딘 응답 -> BookVo
+        BookVo newBookVo = BookConverter.toBookVoFromAladinItem(item); // 알라딘 응답 -> BookVo
         bookDao.insertBook(newBookVo);
 
         return newBookVo.getBookId();
@@ -109,49 +112,5 @@ public class BookServiceImpl implements BookService {
 
         // DB에 없는 경우 알라딘 api 호출 후 DB에 책 저장
         return fetchAndSaveBookByIsbnFromAladin(isbn);
-    }
-
-    // --- converter methods  ---
-
-    // 알라딘 api 호출 후 응답을 BookVo 타입으로 바꾸기
-    private BookVo toBookVo(AladinItemResponseDto item) {
-        BookVo vo = new BookVo();
-        vo.setBookTitle(item.getTitle());
-        vo.setBookAuthor(item.getAuthor());
-        vo.setBookPublisher(item.getPublisher());
-        vo.setBookPublicationDate(item.getPubDate());
-        vo.setBookIsbn(item.getIsbn13());
-        vo.setBookDescription(item.getDescription());
-        vo.setBookPrice(item.getPriceStandard());
-        vo.setBookImageUrl(item.getCover());
-        vo.setBookSalesPoint(item.getSalesPoint());
-        vo.setBookCategory(item.getCategoryName());
-        return vo;
-    }
-
-    // DB 조회 결과 VO -> 검색 응답 DTO 타입으로 바꾸기
-    private BookSearchResponseDto toSearchDto(BookVo vo) {
-        BookSearchResponseDto dto = new BookSearchResponseDto();
-        dto.setTitle(vo.getBookTitle());
-        dto.setAuthor(vo.getBookAuthor());
-        dto.setPublisher(vo.getBookPublisher());
-        dto.setPubDate(vo.getBookPublicationDate());
-        dto.setIsbn13(vo.getBookIsbn());
-        dto.setCover(vo.getBookImageUrl());
-        dto.setCategoryName(vo.getBookCategory());
-        return dto;
-    }
-
-    // 알라딘 조회 결과 DTO를 책 검색 결과 응답 DTO 타입으로 바꾸기
-    private BookSearchResponseDto toSearchDto(AladinItemResponseDto item) {
-        BookSearchResponseDto dto = new BookSearchResponseDto();
-        dto.setTitle(item.getTitle());
-        dto.setAuthor(item.getAuthor());
-        dto.setPublisher(item.getPublisher());
-        dto.setPubDate(item.getPubDate());
-        dto.setIsbn13(item.getIsbn13());
-        dto.setCover(item.getCover());
-        dto.setCategoryName(item.getCategoryName());
-        return dto;
     }
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/dto/ReviewRequestDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/dto/ReviewRequestDto.java
@@ -5,7 +5,7 @@ import lombok.Data;
 @Data
 public class ReviewRequestDto {
     private long userId;
-    private long bookId;
+    private String isbn;
     private Double reviewRating;
     private String reviewContent;
     // userId는 보통 세션/토큰에서 가져오므로 여기서 받지 않음!

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/service/ReviewServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/service/ReviewServiceImpl.java
@@ -1,5 +1,7 @@
 package com.bookspace.domain.review.service;
 
+import com.bookspace.domain.book.dao.BookDao;
+import com.bookspace.domain.book.service.BookService;
 import com.bookspace.domain.review.dto.ReviewRequestDto;
 import com.bookspace.domain.review.dao.ReviewDao;
 import com.bookspace.domain.review.dto.ReviewRequestDto;
@@ -17,11 +19,13 @@ import java.util.List;
 public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewDao reviewDao;
+    private final BookService bookService;
 
     // 1. 리뷰 등록
-    // 없는 책에 대해 리뷰를 등록하려고 하면 -> 404
     @Override
     public void createReview(ReviewRequestDto dto) {
+        Long userId = dto.getUserId();
+        String isbn = dto.getIsbn();
 
         // 예외 처리
         // 1. rating 범위 유효성 검사 (0~5) => 400 BAD_REQUEST
@@ -34,19 +38,20 @@ public class ReviewServiceImpl implements ReviewService {
             throw new RuntimeException("Rating must have at most one decimal place.");
         }
 
-//        // 3. 존재하지 않는 bookId => 404 NOT_FOUND
-//        if (bookDao.selectBookById(dto.getBookId()) == null) {
-//            throw new IllegalArgumentException("Book not found with id: " + dto.getBookId());
-//        }
+        // isbn 기반 DB 책 정보 확인 및 저장
+        Long bookId = bookService.ensureBookExists(isbn);
 
         // 정상 등록 처리
         ReviewVo vo = new ReviewVo();
         vo.setUserId(dto.getUserId());
-        vo.setBookId(dto.getBookId());
+        vo.setBookId(bookId);
         vo.setReviewRating(dto.getReviewRating());
         vo.setReviewContent(dto.getReviewContent());
 
-        reviewDao.insertReview(vo);
+        int rows = reviewDao.insertReview(vo);
+        if( rows != 1 ) {
+            throw new RuntimeException("Failed to insert review");
+        }
     }
 
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/wish/service/WishServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/wish/service/WishServiceImpl.java
@@ -1,11 +1,6 @@
 package com.bookspace.domain.wish.service;
 
-import com.bookspace.domain.book.dao.BookDao;
-import com.bookspace.domain.book.dto.AladinItemResponseDto;
-import com.bookspace.domain.book.dto.AladinListResponseDto;
-import com.bookspace.domain.book.external.AladinClient;
 import com.bookspace.domain.book.service.BookService;
-import com.bookspace.domain.book.vo.BookVo;
 import com.bookspace.domain.wish.dao.WishDao;
 import com.bookspace.domain.wish.dto.WishRequestDto;
 import com.bookspace.domain.wish.dto.WishResponseDto;
@@ -23,9 +18,7 @@ import java.util.List;
 public class WishServiceImpl implements WishService {
 
     private final WishDao wishDao;
-   // private final BookDao bookDao;
     private final BookService bookService;
-    //private final AladinClient aladinClient;
 
     // 1. 찜하기
     @Override
@@ -103,23 +96,6 @@ public class WishServiceImpl implements WishService {
     @Override
     public int getWishCountByUserId(long userId) {
         return wishDao.countWishesByUserId(userId);
-    }
-
-
-    // --converter method-- 정리하기 (공통 로직으로)
-    private BookVo toBookVo(AladinItemResponseDto item) {
-        BookVo vo = new BookVo();
-        vo.setBookTitle(item.getTitle());
-        vo.setBookAuthor(item.getAuthor());
-        vo.setBookPublisher(item.getPublisher());
-        vo.setBookPublicationDate(item.getPubDate());
-        vo.setBookIsbn(item.getIsbn13());
-        vo.setBookDescription(item.getDescription());
-        vo.setBookPrice(item.getPriceStandard());
-        vo.setBookImageUrl(item.getCover());
-        vo.setBookSalesPoint(item.getSalesPoint());
-        vo.setBookCategory(item.getCategoryName());
-        return vo;
     }
 
 }


### PR DESCRIPTION
## 작업 내용
1. 리뷰/포스트 작성 시 클라이언트가 넘겨준  isbn을 기준으로
  서버에서 도서 정보를 자동으로 DB에 추가하거나 기존 도서를 재사용하도록 로직을 추가 (ensureBookExists)
2. 도메인별로 중복되어 있던 도서 변환 로직을 BookConverter로 공통화하여 재사용성 개선