### PR TITLE
[Feat] Security Config 설정 및 로그인 시 JWT 토큰 발급 (#41)

### DIFF
--- a/BookSpace/backend/.idea/modules.xml
+++ b/BookSpace/backend/.idea/modules.xml
@@ -3,7 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/bookspace.main.iml" filepath="$PROJECT_DIR$/.idea/modules/bookspace.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/bookspace.test.iml" filepath="$PROJECT_DIR$/.idea/modules/bookspace.test.iml" />
     </modules>
   </component>
 </project>

--- a/BookSpace/backend/.idea/modules/bookspace.test.iml
+++ b/BookSpace/backend/.idea/modules/bookspace.test.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test">
-      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test" isTestSource="true" generated="true" />
-    </content>
-  </component>
-</module>

--- a/BookSpace/backend/build.gradle
+++ b/BookSpace/backend/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     // Spring Boot 기본
     implementation 'org.springframework.boot:spring-boot-starter'
 
+    //env
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     // Spring Security (Spring 3.4.x -> Security 6.4.x)
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/controller/AuthController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/controller/AuthController.java
@@ -1,0 +1,42 @@
+package com.bookspace.domain.user.controller;
+
+import com.bookspace.domain.user.dto.SignInRequestDto;
+import com.bookspace.domain.user.dto.SignupRequestDto;
+import com.bookspace.domain.user.dto.SingInResponseDto;
+import com.bookspace.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 로그인 API
+     * - userLoginId, userPw 인증 성공 -> jwt 발급
+     */
+    @PostMapping("/login")
+    public SingInResponseDto login(@RequestBody SignInRequestDto dto){
+        // 1) spring security 인증
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(dto.getUserLoginId(), dto.getUserPw())
+        );
+
+        // 2) 인증 성공 -> jwt 발급
+        String accessToken = jwtTokenProvider.createAccessToken(dto.getUserLoginId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(dto.getUserLoginId());
+
+        // 3) 토큰 응답
+        return new SingInResponseDto(accessToken,refreshToken);
+
+    }
+}

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/controller/UserController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.bookspace.domain.user.controller;
 
-import com.bookspace.domain.user.dto.LoginRequestDto;
+import com.bookspace.domain.user.dto.SignInRequestDto;
 import com.bookspace.domain.user.dto.SignupRequestDto;
 import com.bookspace.domain.user.dto.UserResponseDto;
 import com.bookspace.domain.user.dto.UserUpdateRequestDto;
@@ -35,7 +35,7 @@ public class UserController {
     // 4) 인증/인가 로직(Service.login 등)은 모두 제거 또는 대체 예정
     // =============================================================
     @PostMapping("/login")
-    public ResponseEntity<UserResponseDto> login(@RequestBody LoginRequestDto dto) {
+    public ResponseEntity<UserResponseDto> login(@RequestBody SignInRequestDto dto) {
         UserResponseDto response = userService.login(dto);
         return ResponseEntity.ok(response);
     }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/dto/SignInRequestDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/dto/SignInRequestDto.java
@@ -1,12 +1,15 @@
 package com.bookspace.domain.user.dto;
 
-import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * 로그인 요청 DTO
+ * - 클라이언트 -> 서버로 전달되는 로그인 정보
+ */
 @Getter
 @Setter
-public class LoginRequestDto {
+public class SignInRequestDto {
 
     // user가 로그인하는데 필요한 정보
     private String userLoginId;

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/dto/SingInResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/dto/SingInResponseDto.java
@@ -1,0 +1,16 @@
+package com.bookspace.domain.user.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 로그인 응답 DTO
+ * - 서버 -> 클라이언트로 전달되는 JWT 토큰 정보
+ */
+@Getter
+@AllArgsConstructor
+public class SingInResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/service/UserService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.bookspace.domain.user.service;
 
-import com.bookspace.domain.user.dto.LoginRequestDto;
+import com.bookspace.domain.user.dto.SignInRequestDto;
 import com.bookspace.domain.user.dto.SignupRequestDto;
 import com.bookspace.domain.user.dto.UserResponseDto;
 import com.bookspace.domain.user.dto.UserUpdateRequestDto;
@@ -11,7 +11,7 @@ public interface UserService {
     UserResponseDto signup(SignupRequestDto dto);
 
     // 2. 로그인
-    UserResponseDto login(LoginRequestDto dto);
+    UserResponseDto login(SignInRequestDto dto);
 
     // 3. 회원 정보 조회 (by userId)
     UserResponseDto getUserById(long userId);

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/service/UserServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/service/UserServiceImpl.java
@@ -1,7 +1,7 @@
 package com.bookspace.domain.user.service;
 
 import com.bookspace.domain.user.dao.UserDao;
-import com.bookspace.domain.user.dto.LoginRequestDto;
+import com.bookspace.domain.user.dto.SignInRequestDto;
 import com.bookspace.domain.user.dto.SignupRequestDto;
 import com.bookspace.domain.user.dto.UserResponseDto;
 import com.bookspace.domain.user.dto.UserUpdateRequestDto;
@@ -63,7 +63,7 @@ public class UserServiceImpl implements UserService {
     // Spring Security 구현 시 수정 필요
     // =============================================================
     @Override
-    public UserResponseDto login(LoginRequestDto dto) {
+    public UserResponseDto login(SignInRequestDto dto) {
 
         // 2-1. 로그인 아이디로 조회
         UserVo userVo = userDao.selectUserByLoginId(dto.getUserLoginId());

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
@@ -1,20 +1,41 @@
 package com.bookspace.global.security.config;
 
+import com.bookspace.global.security.jwt.JwtAuthenticationFilter;
+import com.bookspace.global.security.jwt.JwtTokenProvider;
+import com.bookspace.global.security.userdetails.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration // Spring 설정 클래스
 @EnableWebSecurity // Spring Security 활성화
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    /**
+     * AuthenticationManager Bean
+     */
+    @Bean
+    public AuthenticationManager authenticationManagerBean(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
 
     // security filter chain 정의
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(jwtTokenProvider,customUserDetailsService);
 
         http
                 .csrf(csrf -> csrf.disable()) // 브라우저 기본 폼 요청 공격 방어 (주로 세션에서 사용됨)
@@ -33,7 +54,8 @@ public class SecurityConfig {
                         ).permitAll() // 인증 없이 가능
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated() // 나머지 요청은 jwt가 필요함
-                );
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/config/WebConfig.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/config/WebConfig.java
@@ -1,0 +1,28 @@
+package com.bookspace.global.security.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * WebConfig
+ * - CORS, Interceptors, Message Converter 설정
+ * - 정적 리소스 매핑, Multipart 설정 (파일 업로드 등)
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+
+        registry.addMapping("/**")
+                .allowedOriginPatterns(
+                        "*"
+                       // "http://localhost:3000", // 프론트
+                )
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .exposedHeaders("Authorization", "Refresh-Token")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/jwt/JwtAuthenticationFilter.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.bookspace.global.security.jwt;
+
+/**
+ * 요청에 포함된 jwt를 검사하고,
+ * 인증 정보(UserDetails)를 SecurityContextHolder에 저장하는 필터
+ * subject = userLoginId 기반으로 인증처리
+ */
+
+import com.bookspace.global.security.userdetails.CustomUserDetails;
+import com.bookspace.global.security.userdetails.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customDetailService;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 1. authorization 헤더에서 토큰 추출
+        String token = resolveToken(request);
+
+        // 2. 토큰 유효성 검사
+        if(token != null && jwtTokenProvider.validateToken(token)) {
+
+            // 3. jwt에서 userLoginId 추출
+            String userLoginId = jwtTokenProvider.getUserId(token);
+
+            // 4. DB에서 UserDetails 조회
+            CustomUserDetails userDetails = (CustomUserDetails)customDetailService.loadUserByUsername(userLoginId);
+
+            // 5. securityContextHolder에 인증 객체 생성 & 정보 저장
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        }
+
+        // 6. 다음 필터로 넘김
+        filterChain.doFilter(request, response);
+    }
+
+    // Authorization 헤더에서 Bearer Token 추출
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if(bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/jwt/JwtExceptionFilter.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/jwt/JwtExceptionFilter.java
@@ -1,0 +1,4 @@
+package com.bookspace.global.security.jwt;
+
+public class JwtExceptionFilter {
+}

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/jwt/JwtTokenProvider.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,81 @@
+package com.bookspace.global.security.jwt;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.security.auth.Subject;
+import java.security.Key;
+import java.util.Date;
+
+/**
+ * JWT를 생성하고 검증
+ * - 인증(auth) 과정에서 토큰 생성
+ * - 인가(authorization) 과정에서는 토큰 안의 정보를 사용해 권한 판단
+ * - JWT subject = userLoginId
+  */
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+
+    // 만료 시간
+    private final long accessTokenExpireMs = 1000L * 60 * 60;           // 1시간
+    private final long refreshTokenExpireMs = 1000L * 60 * 60 * 24 * 14; // 14일
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secret) {
+        System.out.println("🔥 jwt.secret = " + secret);   // 임시 디버깅
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    // Access Token 생성
+    public String createAccessToken(String userLoginId) {
+        return createToken(userLoginId, accessTokenExpireMs);
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(String userLoginId) {
+        return createToken(userLoginId, refreshTokenExpireMs);
+    }
+
+    // 토큰 생성 로직
+    private String createToken(String subject, long expireMs) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expireMs);
+
+        return Jwts.builder()
+                .subject(subject) // userLginId
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(key)
+                .compact();
+
+    }
+
+    // JWT에서 정보 추출
+    public String getUserId(String token) {
+        return Jwts.parser()
+                .verifyWith((SecretKey)key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload().getSubject(); //userLoginUd 반환
+    }
+
+    // JWT 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try{
+            Jwts.parser()
+                    .verifyWith((SecretKey)key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        }catch (JwtException e){
+            return false;
+        }
+    }
+
+}

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/userdetails/CustomUserDetailsService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/userdetails/CustomUserDetailsService.java
@@ -35,5 +35,4 @@ public class CustomUserDetailsService implements UserDetailsService {
 
 
 
-
 }

--- a/BookSpace/backend/src/main/resources/application.yaml
+++ b/BookSpace/backend/src/main/resources/application.yaml
@@ -26,3 +26,8 @@ mybatis:
 
 aladin:
   ttbkey: ${ALADIN_TTB_KEY}
+
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity-ms: ${JWT_ACCESS_TOKEN_VALIDITY_MS:3600000}


### PR DESCRIPTION
## 작업 내용

**1. Spring Security & JWT**
- JwtTokenProvider와 JwtAuthenticationFilter를 추가해 Access/Refresh Token 발급 처리
- /auth/login 컨트롤러를 추가해 로그인 시 JWT 토큰만 응답하도록 구현


## 향후 작업
- refreshToken 저장 / 관리 (DB / redis)
- cors 설정
- /auth/logout api
- @AuthenticationPrincipal을 사용하는 현재 로그인 유저 조회(/auth/me) API 등 추가 구현 고려