### PR TITLE
[feat] signup 아이디/이메일/닉네임 중복확인 기능 구현 (#74)

### DIFF
--- a/BookSpace/frontend/src/components/ui/ValidatedInput.vue
+++ b/BookSpace/frontend/src/components/ui/ValidatedInput.vue
@@ -70,6 +70,11 @@ const props = defineProps({
     type: String,
     default: "",
   },
+  // 필드 구분용 (loginId / email / nickname)
+  field: {
+    type: String,
+    default: "",
+  },
 });
 
 // 부모 -> 자식으로 v-model sync 가능하도록 emit 정의
@@ -89,6 +94,22 @@ const error = computed(() => props.v$.$error);
 // type기반 에러 메시지
 const errorMessage = computed(() => {
   if (!error.value) return "";
+
+
+  // 1) 중복(unique) 에러 (아이디 / 이메일 / 닉네임 등)
+  if (props.v$.unique?.$invalid) {
+    if (props.field === "loginId") {
+      return "이미 사용 중인 아이디입니다.";
+    }
+    if (props.field === "email") {
+      return "이미 사용 중인 이메일입니다.";
+    }
+    if (props.field === "nickname") {
+      return "이미 사용 중인 닉네임입니다.";
+    }
+    return "이미 사용 중인 값입니다.";
+  }  
+
 
   // required
   if (props.v$.required?.$invalid) {

--- a/BookSpace/frontend/src/views/SignupView.vue
+++ b/BookSpace/frontend/src/views/SignupView.vue
@@ -24,6 +24,7 @@
           v-model="loginId"
           :v$="v$.loginId"
           type="text"
+          field="loginId"
           placeholder="아이디"
         />
 
@@ -56,6 +57,7 @@
           v-model="email"
           :v$="v$.email"
           type="email"
+          field="email"
           placeholder="이메일"
         />
 
@@ -64,6 +66,7 @@
           v-model="nickname"
           :v$="v$.nickname"
           type="text"
+          field="nickname"
           placeholder="닉네임"
         />
 
@@ -123,14 +126,36 @@ const isSubmitting = ref(false);
 const userStore = useUserStore();
 const router = useRouter();
 
+// 중복 체크용 함수 정의
+const dupCheck = (type) =>
+    helpers.withAsync(async (value) => {
+      if(!value) return true;
+      try {
+        return await userStore.checkDuplicate(type, value);
+      } catch {
+        return true;
+      }
+    });
+
 // vuelidate 규칙 정의
 const rules = {
-  loginId: { required, minLength: minLength(4) },
-  email: { required, email: emailValidator },
+  loginId: { 
+    required, 
+    minLength: minLength(4),
+    unique: dupCheck("loginId"),
+  },
+  email: { 
+    required, 
+    email: emailValidator,
+    unique: dupCheck("email")
+  },
   password: { required, minLength: minLength(8) },
   confirmPassword: { required, sameAs: sameAs(password) },
   name: { required },
-  nickname: { required },
+  nickname: { 
+    required,
+    unique: dupCheck("nickname")
+  },
   phone: {
     //000-0000-0000
     phoneFormat: helpers.regex(/^\d{3}-\d{4}-\d{4}$/),


### PR DESCRIPTION
- backend에서 구현된 중복체크 API와 연동하여 회원가입 form 작성 시 아이디, 닉네임, 이메일 중복인 경우 화면에 메시지를 출력하는 기능 구현