### PR TITLE
[feat] BE 알라딘 API 기반 도서 검색 및 정렬 기능 추가 (#89)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/controller/BookController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/controller/BookController.java
@@ -20,13 +20,13 @@ public class BookController {
      * @param query 검색어
      * @param searchType 검색 카테고리 (책 이름, 저자명, 출판사)
      */
-    @GetMapping("/search")
-    public List<BookSearchResponseDto> searchBooks(@RequestParam String query,
-                                                   @RequestParam(name="type",required = false,defaultValue = "title") String searchType){
-        System.out.println("query = " + query + ", type = " + searchType);
-
-        return bookService.searchBooks(query, searchType);
-    }
+//    @GetMapping("/search")
+//    public List<BookSearchResponseDto> searchBooks(@RequestParam String query,
+//                                                   @RequestParam(name="type",required = false,defaultValue = "title") String searchType){
+//        System.out.println("query = " + query + ", type = " + searchType);
+//
+//        return bookService.searchBooks(query, searchType);
+//    }
 
     /**
      * 2. ISBN 기반 단건 조회: 유저 액션 (찜, 포스트, 리뷰 작성) 처리할 때 DB에서 bookId 생성용
@@ -39,4 +39,26 @@ public class BookController {
         //return bookService.searchBooks(isbn).get(0);
         return null;
     }
+
+    /**
+     * 3. 책 검색 (알라딘 API 기반)
+     * - 알라딘 API에서 직접 도서 목록을 조회
+     * - DB는 사용하지 않으며, 모든 검색 결과는 알라딘 데이터 기준으로 구성됨
+     * - 정렬(sort) 값은 내부적으로 알라딘 API의 정렬 키(PublishTime, SalesPoint 등)로 매핑되어 전달됨
+     *
+     * @param query 검색어 (필수)
+     * @param searchType 검색 카테고리 (책 제목, 저자명, 출판사, ISBN) — 기본값: "title"
+     * @param sort 정렬 기준 (latest: 출간일 최신순 / popular: 판매지수순 / accuracy: 정확도순) — 기본값: "latest"
+     *
+     * @return 알라딘 API에서 조회된 도서 목록
+     */
+    @GetMapping("/search")
+    public List<BookSearchResponseDto> searchBooksFromAladin(
+            @RequestParam String query,
+            @RequestParam(name = "type", required = false, defaultValue = "title") String searchType,
+            @RequestParam(name = "sort", required = false, defaultValue = "latest") String sort
+    ) {
+        return bookService.searchBooksFromAladin(query, searchType, sort);
+    }
+
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/external/AladinClient.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/external/AladinClient.java
@@ -26,20 +26,41 @@ public class AladinClient {
     private final RestTemplate restTemplate = new RestTemplate(); // http 요청
     private final ObjectMapper objectMapper = new ObjectMapper(); // json 파싱
 
-    public AladinListResponseDto searchBooks(String query, String searchType, int maxResults){
+    // 기존에 파라미터 query와 searchType 2개만 받는 메서드 유지 (오버로드 메서드)
+    // 다른 파트에서 파라미터 Sort가 포함되지 않은 searchBooks()를 호출하고 있을수도 있기 때문에
+    // Sort의 default값을 설정하여 에러발생 방지
+    public AladinListResponseDto searchBooks(String query, String searchType, int maxResults) {
+        return searchBooks(query, searchType, "latest", maxResults);
+    }
+
+    // query, searchType, sort => 3개의 파라미터
+    public AladinListResponseDto searchBooks(String query, String searchType, String sort, int maxResults){
         try{
             // 검색 타입 -> 알라딘 api 쿼리 타입에 맞게 설정
             String queryType = switch (searchType) {
                 case "author" -> "Author";
                 case "publisher" -> "Publisher";
+                case "isbn" -> "ISBN";
                 default -> "Title";
             };
 
+            // 정렬 기준 -> 알라딘 Sort 파라미터로 매핑
+            String sortKey = (sort == null || sort.isBlank()) ? "latest" : sort.toLowerCase();
+            String sortType = switch (sortKey) {
+                case "latest" -> "PublishTime";   // 출간일 최신순
+                case "popular" -> "SalesPoint";   // 판매지수(인기순)
+                case "accuracy" -> "Accuracy";   // 정확도순
+                default -> "PublishTime";         // 기본: 출간일순
+            };
+
+
             // 요청 url 구성
+            // sort 추가
             String url = UriComponentsBuilder.fromHttpUrl(ITEM_SEARCH_URL)
                     .queryParam("ttbkey", ttbKey)
                     .queryParam("Query", query)
                     .queryParam("QueryType", queryType)
+                    .queryParam("Sort", sortType)
                     .queryParam("MaxResults", maxResults)
                     .queryParam("start", 1)
                     .queryParam("SearchTarget", "Book")

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookService.java
@@ -14,4 +14,8 @@ public interface BookService {
     // DB에 없을 경우, 알라딘 api 호출 . DB 저장 -> book_id 반환 (유저 액션: 찜, post, review)
     Long ensureBookExists(String  isbn);
 
+    // 알라딘 API로만 책 조회
+    List<BookSearchResponseDto> searchBooksFromAladin(String query, String searchType, String sort);
+
+
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
@@ -113,4 +113,19 @@ public class BookServiceImpl implements BookService {
         // DB에 없는 경우 알라딘 api 호출 후 DB에 책 저장
         return fetchAndSaveBookByIsbnFromAladin(isbn);
     }
+
+    // 알라딘 API로만 책 조회 (3개의 파라미터)
+    @Override
+    public List<BookSearchResponseDto> searchBooksFromAladin(String query, String searchType, String sort) {
+        AladinListResponseDto apiResponse =
+                aladinClient.searchBooks(query, searchType, sort, 20);
+
+        if (apiResponse == null || apiResponse.getItems() == null) {
+            return List.of();
+        }
+
+        return apiResponse.getItems().stream()
+                .map(BookConverter::toSearchResponseFromAladinItem)
+                .toList();
+    }
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
                                 "/join",
                                 "/users/**",
                                 "/auth/**",
-                                "/posts/**"
+                                "/posts/**",
+                                "/books/**"
                         ).permitAll() // 인증 없이 가능
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated() // 나머지 요청은 jwt가 필요함

--- a/BookSpace/frontend/src/components/book/BookSearchInput.vue
+++ b/BookSpace/frontend/src/components/book/BookSearchInput.vue
@@ -19,7 +19,7 @@
         <!-- 검색창 -->
         <SearchInput 
             v-model="searchQuery" 
-            placeholder="검색어를 입력하세요..." 
+            placeholder="검색어를 입력하세요" 
             @search="onSearch"
         />
     </section> 


### PR DESCRIPTION
### /books/search 엔드포인트 구현
- 알라딘 API만 사용하여 조회하도록 수정
- 정렬 기능 추가 (출간일순, 정확도순, 인기순 가능)
=> 파라미터 총 3개 (query, type, sort)

### 프론트 연동을 위해 Security Config에서 /books/** 임시 허용
