### PR TITLE
[feat] 알라딘 API에 description 및 큰 사이즈 cover 이미지 지원 추가 (#89)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/converter/BookConverter.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/converter/BookConverter.java
@@ -44,6 +44,7 @@ public final class BookConverter {
         dto.setIsbn13(vo.getBookIsbn());
         dto.setCover(vo.getBookImageUrl());
         dto.setCategoryName(vo.getBookCategory());
+        dto.setDescription(vo.getBookDescription());
         return dto;
     }
 
@@ -62,6 +63,7 @@ public final class BookConverter {
         dto.setIsbn13(item.getIsbn13());
         dto.setCover(item.getCover());
         dto.setCategoryName(item.getCategoryName());
+        dto.setDescription(item.getDescription());
         return dto;
     }
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/dto/BookSearchResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/dto/BookSearchResponseDto.java
@@ -15,4 +15,5 @@ public class BookSearchResponseDto {
     private String isbn13;
     private String cover; // 책 표지 url
     private String categoryName;
+    private String description;
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/external/AladinClient.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/external/AladinClient.java
@@ -64,6 +64,7 @@ public class AladinClient {
                     .queryParam("MaxResults", maxResults)
                     .queryParam("start", 1)
                     .queryParam("SearchTarget", "Book")
+                    .queryParam("Cover", "Big")
                     .queryParam("output", "js")
                     .queryParam("Version", "20131101")
                     .build()

--- a/BookSpace/frontend/src/components/book/BookSearchInput.vue
+++ b/BookSpace/frontend/src/components/book/BookSearchInput.vue
@@ -11,7 +11,7 @@
                 focus-visible:border-ring
                 "
             >
-            <option value="title">책제목</option>
+            <option value="title">제목</option>
             <option value="author">저자</option>
             <option value="publisher">출판사</option>
         </select>
@@ -22,10 +22,12 @@
             placeholder="검색어를 입력하세요" 
             @search="onSearch"
         />
+
+        <Button class="w-16 h-5 text-white font-extrabold">검색</Button>
     </section> 
 
     <!-- 정렬기준 선택 -->
-    <section class="mt-6 mb-6 flex justify-end gap-4">
+    <section class="mt-6 mb-6 flex justify-end gap-3">
         <span
             @click="setSort('latest')"
             :class="[
@@ -36,7 +38,16 @@
             출간일순
         </span>
 
-
+        <span
+            @click="setSort('accuracy')"
+            :class="[
+                'cursor-pointer text-sm',
+                sort === 'accuracy' ? 'font-extrabold text-primary' : 'font-normal'
+            ]"
+        >
+            정확도순
+        </span>
+        
         <span
             @click="setSort('popular')"
             :class="[
@@ -52,6 +63,7 @@
 <script setup>
 import { ref } from 'vue';
 import SearchInput from '../common/SearchInput.vue';
+import Button from '../ui/Button.vue';
 
 const type = ref("title");
 const sort = ref("latest");


### PR DESCRIPTION
- 도서 상세 조회 페이지에 필요한 책소개(description) 정보를 BookResponseDto에 추가
- 책표지 이미지가 기존에 85px로 너무 작아 화질이 깨져서 보이는 이슈 -> 알라딘이 제공하는 가장 큰 사이즈인 Cover=Big (200px)로 받아오도록 추가