### PR TITLE
[feat] 검색어 없이 /books 메인페이지에서 사용할 기본 도서 목록 조회 기능 구현 (#89)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/controller/BookController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/controller/BookController.java
@@ -61,4 +61,22 @@ public class BookController {
         return bookService.searchBooksFromAladin(query, searchType, sort);
     }
 
+    /**
+     * 4. 기본 도서 목록 조회 (검색어 없이)
+     * - 메인 도서 목록 화면에서 사용하는 기본 리스트
+     * - 정렬(sort)을 제공하지 않고, "어떤 목록을 가져올지"만 선택
+     *
+     * @param type 기본 목록 종류
+     *             - new : 신간 전체 목록 (출간일 최신순)
+     *             - bestseller : 베스트셀러 목록 (판매지수순)
+     *
+     * @return 알라딘 ItemList API 기반 기본 도서 목록
+     */
+    @GetMapping // GET /books
+    public List<BookSearchResponseDto> getDefaultBooks(
+            @RequestParam(name = "type", required = false, defaultValue = "bestseller") String type
+    ) {
+        // type: "new" | "bestseller"
+        return bookService.getDefaultBooksFromAladin(type);
+    }
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/external/AladinClient.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/external/AladinClient.java
@@ -22,6 +22,7 @@ public class AladinClient {
     private String ttbKey;
 
     private static final String ITEM_SEARCH_URL = "https://www.aladin.co.kr/ttb/api/ItemSearch.aspx";
+    private static final String ITEM_LIST_URL   = "https://www.aladin.co.kr/ttb/api/ItemList.aspx"; // 기본 목록 조회용
 
     private final RestTemplate restTemplate = new RestTemplate(); // http 요청
     private final ObjectMapper objectMapper = new ObjectMapper(); // json 파싱
@@ -86,6 +87,62 @@ public class AladinClient {
         }
         catch(Exception e){
             log.error("알라딘 API 도서 검색 실패",query, e);
+            return null;
+        }
+    }
+
+    // 검색어 없이 기본 도서 목록 조회 (/books 메인화면에 보여질 기본 도서 목록)
+    public AladinListResponseDto fetchDefaultBooks(String type, int maxResults) {
+        try {
+            String key = (type == null || type.isBlank()) ? "bestseller" : type.toLowerCase();
+
+            String queryType;  // ItemList API의 QueryType
+            String sortType;   // 알라딘 Sort
+
+            switch (key) {
+                case "bestseller" -> {
+                    // 베스트셀러 목록 (인기순)
+                    queryType = "BestSeller";
+                    sortType = "SalesPoint";
+                }
+                case "new" -> {
+                    // 신간 전체 (출간일 최신순)
+                    queryType = "ItemNewAll";
+                    sortType = "PublishTime";
+                }
+                default -> {
+                    // 이상한 값 오면 기본은 신간 최신순
+                    queryType = "ItemNewAll";
+                    sortType = "PublishTime";
+                }
+            }
+
+            String url = UriComponentsBuilder.fromHttpUrl(ITEM_LIST_URL)
+                    .queryParam("ttbkey", ttbKey)
+                    .queryParam("QueryType", queryType)
+                    .queryParam("Sort", sortType)
+                    .queryParam("MaxResults", maxResults)
+                    .queryParam("start", 1)
+                    .queryParam("SearchTarget", "Book")
+                    .queryParam("Cover", "Big")
+                    .queryParam("output", "js")
+                    .queryParam("Version", "20131101")
+                    .build()
+                    .toUriString();
+
+            log.info("[Aladin][Default] request URL = {}", url);
+
+            String responseBody = restTemplate.getForObject(url, String.class);
+
+            log.info("[Aladin][Default] raw response = {}", responseBody);
+            if (responseBody != null && responseBody.contains("\"errorCode\"")) {
+                log.error("[Aladin][Default] ERROR RESPONSE: {}", responseBody);
+                return null;
+            }
+
+            return objectMapper.readValue(responseBody, AladinListResponseDto.class);
+        } catch (Exception e) {
+            log.error("알라딘 API 기본 도서 목록 조회 실패", e);
             return null;
         }
     }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookService.java
@@ -17,5 +17,6 @@ public interface BookService {
     // 알라딘 API로만 책 조회
     List<BookSearchResponseDto> searchBooksFromAladin(String query, String searchType, String sort);
 
-
+    // 검색어 없이 알라딘 API 호출하여 기본 목록 조회
+    List<BookSearchResponseDto> getDefaultBooksFromAladin(String type);
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
@@ -128,4 +128,24 @@ public class BookServiceImpl implements BookService {
                 .map(BookConverter::toSearchResponseFromAladinItem)
                 .toList();
     }
+
+    /**
+     * [기본 목록] 검색어 없이 알라딘에서 기본 도서 리스트 조회
+     * - 메인 도서 목록 화면에서 사용
+     * - type: new | bestseller
+     */
+    @Override
+    public List<BookSearchResponseDto> getDefaultBooksFromAladin(String type) {
+        // type: "new" | "bestseller"
+        AladinListResponseDto apiResponse =
+                aladinClient.fetchDefaultBooks(type, 100);
+
+        if (apiResponse == null || apiResponse.getItems() == null) {
+            return List.of();
+        }
+
+        return apiResponse.getItems().stream()
+                .map(BookConverter::toSearchResponseFromAladinItem)
+                .toList();
+    }
 }


### PR DESCRIPTION
메인 도서 목록 화면에서 검색어 없이 보여줄 기본 도서 리스트를 제공하기 위해, 알라딘 ItemList API 기반으로 신간 / 베스트셀러 목록 조회 기능을 추가

- GET /books?type={new|bestseller}
- type 기본값을 bestseller로 설정

### 작업목적
- 검색어 없이 메인 도서 목록에 표시될 도서 목록의 필요성