### PR TITLE
[FE_FEAT] Community Post 상세조회 페이지 UI & 로직 추가 및 새로고침 시 유저 상태 전역 저장 설정 …

### DIFF
--- a/BookSpace/backend/.idea/modules/bookspace.test.iml
+++ b/BookSpace/backend/.idea/modules/bookspace.test.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test">
-      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test" isTestSource="true" generated="true" />
-    </content>
-  </component>
-</module>

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/dto/PostResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/dto/PostResponseDto.java
@@ -5,20 +5,24 @@ import java.time.LocalDateTime;
 
 // 단건 조회에서 내려줄 Dto
 @Data
-public class PostResponseDto {
+public class PostlResponseDto {
     private long postId;
     private long userId;
     private long bookId;
+
     private String bookTitle;
     private String bookAuthor;
     private String bookImageUrl;
+
     private String postTitle;
     private String postContent;
     private LocalDateTime postDate;
     private int postViewCnt;
     private LocalDateTime postLastModified;
+
     private int likeCount; // 해당 post의 좋아요 총 개수
-    private boolean isLiked; // 로그인한 유저라면 유저가 좋아요를 눌렀는지
+    private boolean liked; // 로그인한 유저라면 유저가 좋아요를 눌렀는지
     private int commentCount;
+
     private String userNickName;
 }

--- a/BookSpace/frontend/src/App.vue
+++ b/BookSpace/frontend/src/App.vue
@@ -21,12 +21,15 @@ const userStore = useUserStore();
 
 // 앱이 처음 로드되거나 새로고침됐을 떄 한 번 실행
 onMounted(async () => {
+  // 인증 상태 복구 (localStorage -> pinia)
+  authStore.restoreAuth();
+
   // 로그인 상태가 아니면 아무것도 안 함
   if (!authStore.isLoggedIn) {
     return;
   }
 
-  // 2) 이미 me가 채워져 있으면 다시 호출할 필요 없음
+  // 이미 me가 채워져 있으면 다시 호출할 필요 없음
   if (userStore.me && userStore.me.value) {
     return;
   }

--- a/BookSpace/frontend/src/api/postApi.js
+++ b/BookSpace/frontend/src/api/postApi.js
@@ -18,7 +18,7 @@ export const createPostApi = async (payload) => {
   return res.data;
 };
 
-// [R] 게시글 목록 조회 (페이징)
+// [R] 게시글 전체 조회 (페이징)
 export const fetchPosts = async ({ pageParam = 0 }) => {
   const res = await httpClient.get("/posts", {
     params: {
@@ -39,17 +39,22 @@ export const fetchPosts = async ({ pageParam = 0 }) => {
   };
 };
 
+// [R] 게시글 단건 조회
+export const fetchPostDetail = async (postId) => {
+  const res = await httpClient.get(`/posts/${postId}`);
+  return res.data;
+};
+
 // 게시글 좋아요
 export const postLikes = async (postId) => {
-  console.log("liked");
+  console.log("post likes");
   const res = await httpClient.post(`/posts/${postId}/like`);
   return res.data;
 };
 
 // 게시글 좋아요 취소
 export const deleteLikes = async (postId) => {
-  console.log("disliked");
-
+  console.log("post likes non nonono");
   const res = await httpClient.delete(`/posts/${postId}/like`);
   return res.data;
 };

--- a/BookSpace/frontend/src/components/community/PostCard.vue
+++ b/BookSpace/frontend/src/components/community/PostCard.vue
@@ -130,9 +130,9 @@ const isLiked = ref(!!props.post.liked);
 
 // 좋아요 토글 (낙관적 업데이트)
 const toggleLikeMutation = useMutation({
-  mutationFn: ({ postId, nextLiked }) =>
-    nextLiked ? postLikes(postId) : deleteLikes(postId),
-  onMutate: async ({ nextLiked }) => {
+  mutationFn: (nextLiked) =>
+    nextLiked ? postLikes(props.post.postId) : deleteLikes(props.post.postId),
+  onMutate: async (nextLiked) => {
     // 현재 목록 쿼리 취소
     await queryClient.cancelQueries({ queryKey: ["posts"] });
     await queryClient.cancelQueries({ queryKey: ["posts", "latest"] });
@@ -190,14 +190,14 @@ const toggleLike = async () => {
   }
 
   const nextLiked = !isLiked.value;
-  await toggleLikeMutation.mutateAsync({
-    postId: props.post.postId,
-    nextLiked,
-  });
+  await toggleLikeMutation.mutateAsync(nextLiked);
 };
 
 const goToPostDetail = () => {
-  // TODO 게시글 상세 페이지 조회
+  router.push({
+    name: "postDetail",
+    params: { postId: props.post.postId },
+  });
 };
 </script>
 

--- a/BookSpace/frontend/src/stores/authStore.js
+++ b/BookSpace/frontend/src/stores/authStore.js
@@ -8,6 +8,7 @@ export const useAuthStore = defineStore("auth", {
     // user: null, // 로그인한 사용자 정보 (나중에 받아오기)
     token: localStorage.getItem("accessToken") || null, // 새로고침해도 토큰 유지
     isLoggedIn: !!localStorage.getItem("accessToken"), // 토큰 존재 여부로 로그인 상태 판별
+    isReady: false,
   }),
 
   actions: {
@@ -35,5 +36,12 @@ export const useAuthStore = defineStore("auth", {
       const userStore = useUserStore();
       userStore.clearMe();
     },
-  }
+
+    restoreAuth() {
+      const token = localStorage.getItem("accessToken");
+      this.token = token;
+      this.isLoggedIn = !!token;
+      this.isReady = true;
+    },
+  },
 });

--- a/BookSpace/frontend/src/views/CommunityView.vue
+++ b/BookSpace/frontend/src/views/CommunityView.vue
@@ -82,9 +82,13 @@ import Button from "../components/ui/Button.vue";
 import { PlusIcon } from "lucide-vue-next";
 import { ArrowUpIcon } from "@heroicons/vue/24/solid";
 import PostCard from "@/components/community/PostCard";
-import { useInfiniteQuery, useQuery } from "@tanstack/vue-query";
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/vue-query";
 import { fetchPosts } from "../api/postApi.js";
-import { computed, onMounted, ref, onUnmounted } from "vue";
+import { computed, onMounted, ref, onUnmounted, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useToast } from "@/composables/useToast";
 import { useAuthStore } from "@/stores/authStore";
@@ -92,6 +96,7 @@ import { useAuthStore } from "@/stores/authStore";
 const authStore = useAuthStore();
 const router = useRouter();
 const { toast } = useToast();
+const queryClient = useQueryClient();
 
 // 게시글 목록 경로: data.pages[0].content.posts
 const {

--- a/BookSpace/frontend/src/views/PostDetailView.vue
+++ b/BookSpace/frontend/src/views/PostDetailView.vue
@@ -1,13 +1,230 @@
 <template>
-    <div>
-        <h2>게시글 상세화면</h2>
+  <section class="max-w-5xl mx-auto mt-6 space-y-6">
+    <div class="flex items-center justify-between gap-4">
+      <Button variant="ghost" class="gap-2 px-3" @click="goBack">
+        <ArrowLeft class="w-4 h-4" />
+        목록으로
+      </Button>
     </div>
+
+    <div v-if="isLoading && !post" class="py-12 text-center">
+      게시글을 불러오는 중입니다...
+    </div>
+
+    <div v-else-if="isError && !post" class="py-12 text-center">
+      <p class="mb-3 text-destructive">게시글을 불러오지 못했습니다.</p>
+      <Button variant="outline" @click="refetch">다시 시도</Button>
+    </div>
+
+    <template v-else-if="post">
+      <article class="p-6 space-y-5 border shadow-sm rounded-xl bg-card">
+        <header class="flex items-start justify-between gap-4">
+          <div class="flex items-center gap-3">
+            <img
+              :src="post.userProfileImage || defaultProfile"
+              alt="작성자 프로필"
+              class="object-cover w-12 h-12 rounded-full"
+            />
+            <div>
+              <p class="font-semibold text-foreground">
+                {{ post.userNickName }}
+              </p>
+              <p class="text-sm text-muted-foreground">
+                {{ formattedDate }}
+              </p>
+            </div>
+          </div>
+        </header>
+
+        <div class="space-y-4">
+          <h1 class="text-2xl font-semibold text-foreground">
+            {{ post.postTitle }}
+          </h1>
+
+          <div class="space-y-3">
+            <Separator />
+            <div class="flex items-start gap-4 px-1">
+              <div class="h-40 overflow-hidden rounded-md w-28 bg-muted">
+                <img
+                  :src="post.bookImageUrl || defaultBook"
+                  alt="book cover"
+                  class="object-cover w-full h-full"
+                />
+              </div>
+              <div class="flex-1 space-y-1">
+                <p class="text-lg font-semibold text-foreground">
+                  {{ post.bookTitle || "도서 정보 없음" }}
+                </p>
+                <p class="text-sm text-muted-foreground">
+                  {{
+                    post.bookAuthor || "작성자가 도서 정보를 추가하지 않았어요."
+                  }}
+                </p>
+                <p v-if="post.isbn" class="text-xs text-muted-foreground">
+                  ISBN {{ post.isbn }}
+                </p>
+              </div>
+            </div>
+            <Separator />
+          </div>
+
+          <div
+            class="flex flex-wrap items-center gap-3 text-sm text-muted-foreground"
+          >
+            <button
+              type="button"
+              class="flex items-center gap-1 px-3 py-1 transition rounded-full group"
+              :class="
+                isLiked
+                  ? 'text-destructive bg-destructive/10'
+                  : 'hover:bg-muted'
+              "
+              :disabled="toggleLikeMutation.isPending.value"
+              @click="handleToggleLike"
+            >
+              <HeartIcon
+                class="w-4 h-4 transition-colors"
+                :class="
+                  isLiked
+                    ? 'text-destructive'
+                    : 'text-muted-foreground group-hover:text-destructive'
+                "
+              />
+              <span :class="isLiked ? 'font-semibold text-foreground' : ''">
+                {{ likeCount }}개의 좋아요
+              </span>
+            </button>
+            <span class="text-muted-foreground">|</span>
+            <div class="flex items-center gap-1">
+              <MessageSquare class="w-4 h-4" />
+              <span>{{ post.commentCount ?? 0 }}개의 댓글</span>
+            </div>
+            <span class="text-muted-foreground">|</span>
+            <div class="flex items-center gap-1">
+              <Eye class="w-4 h-4" />
+              <span>{{ post.postViewCnt ?? 0 }}회 조회</span>
+            </div>
+          </div>
+        </div>
+
+        <p class="leading-relaxed whitespace-pre-line text-foreground">
+          {{ content }}
+        </p>
+      </article>
+
+      <div v-if="isError" class="flex items-center gap-3 text-sm">
+        <span class="text-destructive"
+          >최신 정보를 불러오는 데 실패했습니다.</span
+        >
+        <Button variant="ghost" size="sm" @click="refetch">
+          다시 불러오기
+        </Button>
+      </div>
+    </template>
+  </section>
 </template>
 
 <script setup>
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
+import ViewHeader from "@/components/common/ViewHeader.vue";
+import Button from "@/components/ui/Button.vue";
+import { useToast } from "@/composables/useToast";
+import Separator from "@/components/ui/Separator.vue";
+import { deleteLikes, fetchPostDetail, postLikes } from "@/api/postApi";
+import { MessageSquare, Eye, ArrowLeft } from "lucide-vue-next";
+import { HeartIcon } from "@heroicons/vue/24/solid";
+import { useAuthStore } from "@/stores/authStore";
 
+const { toast } = useToast();
+
+const props = defineProps({
+  postId: {
+    type: [String, Number],
+    required: true,
+  },
+});
+
+const router = useRouter();
+const queryClient = useQueryClient();
+const authStore = useAuthStore();
+
+const { data, isLoading, isError, refetch } = useQuery({
+  queryKey: ["post", props.postId],
+  queryFn: () => fetchPostDetail(props.postId),
+  enabled: !!props.postId,
+  staleTime: 0,
+});
+
+const post = computed(() => data.value);
+const likeCount = computed(() => post.value?.likeCount ?? 0);
+const isLiked = computed(() => !!post.value?.liked);
+
+const formattedDate = computed(() => {
+  const dateString = post.value?.postDate;
+  if (!dateString) return "";
+  const date = new Date(dateString);
+  return date.toLocaleString("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+});
+
+const content = computed(() => post.value?.postContent ?? "");
+
+const defaultProfile = "/default-profile.png";
+const defaultBook = "/default-book.png";
+
+const goBack = () => {
+  router.back();
+};
+
+const toggleLikeMutation = useMutation({
+  mutationFn: ({ nextLiked }) =>
+    nextLiked ? postLikes(props.postId) : deleteLikes(props.postId),
+  onMutate: async ({ nextLiked }) => {
+    await queryClient.cancelQueries({ queryKey: ["post", props.postId] });
+    const previous = queryClient.getQueryData(["post", props.postId]);
+
+    queryClient.setQueryData(["post", props.postId], (old) => {
+      if (!old) return old;
+      const updatedCount = Math.max(
+        0,
+        (old.likeCount ?? 0) + (nextLiked ? 1 : -1)
+      );
+      return { ...old, liked: nextLiked, likeCount: updatedCount };
+    });
+
+    return { previous };
+  },
+  onError: (_err, _vars, ctx) => {
+    if (ctx?.previous) {
+      queryClient.setQueryData(["post", props.postId], ctx.previous);
+    }
+  },
+  onSettled: () => {
+    queryClient.invalidateQueries({ queryKey: ["post", props.postId] });
+  },
+});
+
+const handleToggleLike = async () => {
+  if (!authStore.isLoggedIn) {
+    toast({
+      title: "로그인이 필요한 서비스입니다.",
+      description: "좋아요를 누르려면 먼저 로그인해주세요.",
+    });
+    const redirectPath = router.resolve({
+      name: "postDetail",
+      params: { postId: props.postId },
+    }).path;
+    router.push({ name: "signin", query: { redirect: redirectPath } });
+    return;
+  }
+
+  if (toggleLikeMutation.isPending.value) return;
+
+  const nextLiked = !isLiked.value;
+  await toggleLikeMutation.mutateAsync({ nextLiked });
+};
 </script>
-
-<style scoped>
-
-</style>

--- a/BookSpace/frontend/src/views/SignInView.vue
+++ b/BookSpace/frontend/src/views/SignInView.vue
@@ -98,7 +98,7 @@ const login = async () => {
 
   try {
     await authStore.login({
-      userLoginId: loginId.value, // 🔹 백엔드 DTO 필드명에 맞춰서 매핑
+      userLoginId: loginId.value,
       userPw: password.value,
     });
 


### PR DESCRIPTION
## PR Summary

- **Type**: feat
- **Scope**: FE(post-detail)
- **Issue**: #79 / Refs #

---

## 작업 내용
**1. Views > PostDetail & API**
- 게시글 상세 조회 페이지 UI 구현
- vue-query를 사용한 상세 데이터 패칭 및 캐싱 처리
- 좋아요 토글 기능 추가 (optimistic update 적용)
- 비로그인 유저 좋아요 클릭 시 로그인 유도 + redirect 처리 (토스트 메세지 알림)
- 로딩 / 에러 / 재시도 상태에 따른 UI 분기 처리
- 새로고침/직접 접근 시에도 로그인 상태 기반 UI 일관성 보장

**2. 새로고침 / 직접 접근 시 로그인 상태 기반 UI 렌더링**
- 앱 마운트 시 인증 상태를 복구하는 restoreAuth 로직 추가 (store > authStore, App.vue)
---

## Changes

### Frontend

- **UI/UX**
    - 게시글 상세 조회 레이아웃 구현
    - 작성자 정보, 도서 정보, 본문, 좋아요/댓글/조회수 영역 구성
    - Skeleton 없이 로딩/에러 메시지 기반 상태 표현
- **State / Data Flow**
    - `useQuery`로 게시글 상세 데이터 관리
    - queryKey: `["post", postId]`
    - staleTime = 0으로 항상 최신 데이터 조회
- **API Integration**
    - 게시글 상세 조회 API 연동
    - 좋아요 등록 / 취소 API 연동
    - 좋아요 토글 시 optimistic update 적용
- **Routing**
    - 비로그인 상태에서 좋아요 클릭 시 로그인 페이지로 이동
    - 로그인 후 다시 상세 페이지로 돌아올 수 있도록 redirect query 처리
- **Edge Cases / Errors**
    - 좋아요 요청 중 중복 클릭 방지
    - optimistic update 실패 시 이전 상태로 rollback
    - 상세 조회 실패 시 재시도 버튼 제공

---

### Backend

- N/A

---

## How to Test

1. 프론트엔드 실행
2. 게시글 목록에서 게시글 클릭 → 상세 페이지 진입
3. 로그인 / 비로그인 상태 각각 테스트

**Expected**

- 게시글 상세 정보 정상 렌더링
- 비로그인 유저:
    - 좋아요 클릭 시 로그인 페이지로 이동
- 로그인 유저:
    - 좋아요 클릭 시 즉시 UI 반영
    - 새로고침 후에도 좋아요 상태 유지