### PR TITLE
[BE_Edit] Post 도메인 전체조회 및 단일 조회 api 응답 타입 수정 및 유저 선택적 인증 적용 (#79)

### DIFF
--- a/BookSpace/backend/.idea/compiler.xml
+++ b/BookSpace/backend/.idea/compiler.xml
@@ -8,8 +8,16 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.34/ec547ef414ab1d2c040118fb9c1c265ada63af14/lombok-1.18.34.jar" />
         </processorPath>
-        <module name="bookspace.main" />
         <module name="bookspace.test" />
+      </profile>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.34/ec547ef414ab1d2c040118fb9c1c265ada63af14/lombok-1.18.34.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.mapstruct/mapstruct-processor/1.5.5.Final/897f6f115930b936287bef552bf5fe28cc64717d/mapstruct-processor-1.5.5.Final.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-configuration-processor/3.4.0/fc571725ca8b92a09a48ccce8ab1547464b0bd8b/spring-boot-configuration-processor-3.4.0.jar" />
+        </processorPath>
+        <module name="bookspace.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />

--- a/BookSpace/backend/.idea/data_source_mapping.xml
+++ b/BookSpace/backend/.idea/data_source_mapping.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourcePerFileMappings">
-    <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/eabfd39e-4726-42d0-b9cc-22e95c2863d8/console.sql" value="eabfd39e-4726-42d0-b9cc-22e95c2863d8" />
     <file url="file://$PROJECT_DIR$/src/main/resources/mappers/PostMapper.xml" value="eabfd39e-4726-42d0-b9cc-22e95c2863d8" />
   </component>
 </project>

--- a/BookSpace/backend/.idea/modules.xml
+++ b/BookSpace/backend/.idea/modules.xml
@@ -3,7 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/bookspace.main.iml" filepath="$PROJECT_DIR$/.idea/modules/bookspace.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/bookspace.test.iml" filepath="$PROJECT_DIR$/.idea/modules/bookspace.test.iml" />
     </modules>
   </component>
 </project>

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
@@ -5,7 +5,9 @@ import java.util.List;
 import com.bookspace.domain.post.dto.PostPageResponseDto;
 import com.bookspace.global.security.userdetails.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import com.bookspace.domain.post.dto.PostRequestDto;
@@ -37,27 +39,27 @@ public class PostController {
     @GetMapping
     public ResponseEntity<PostPageResponseDto> getAllPosts(@RequestParam(defaultValue = "0") int page,
                                                                  @RequestParam(defaultValue = "10") int size,
-                                                                @AuthenticationPrincipal CustomUserDetails user) {
-        Long userId = (user!=null)?user.getUserId():null; // 비로그인 userId = null
+                                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails != null ? userDetails.getUserId() : null;
+        System.out.println(SecurityContextHolder.getContext().getAuthentication());
+
+        System.out.println("userId = " + userId);
+
         PostPageResponseDto response = postService.getAllPosts(page,size,userId);
         return ResponseEntity.ok(response);
     }
 
     // 3. 단건 조회
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponseDto> getPost(@PathVariable long postId) {
-        return ResponseEntity.ok(postService.getPostById(postId));
+    public ResponseEntity<PostResponseDto> getPost(@PathVariable long postId, @AuthenticationPrincipal CustomUserDetails user  ) {
+
+        Long userId = (user!=null)?user.getUserId():null;
+        System.out.println("userId = " + userId);
+
+        PostResponseDto response = postService.getPostById(postId, userId);
+        return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/likes")
-    public ResponseEntity<List<PostResponseDto>> getLikedPosts() {
-        // TODO 로그인 로직 구현 후 수정 (로그인한 유저만)
-        Long userId = 1L; // userId 반드시 필요함
-
-        List<PostResponseDto> likedPosts = postService.getLikedPostsByUserId(userId);
-
-        return ResponseEntity.ok(likedPosts);
-    }
 
     // 4. 게시글 수정
     @PutMapping("/{postId}")
@@ -100,6 +102,17 @@ public class PostController {
     // /posts/search?keyword=강아
     public ResponseEntity<List<PostResponseDto>> getPostsByKeyword(@RequestParam String keyword) {
         return ResponseEntity.ok(postService.getPostsByKeyword(keyword));
+    }
+
+    // 9. 유저가 좋아하는 게시물 목록 조회
+    @GetMapping("/likes")
+    public ResponseEntity<List<PostResponseDto>> getLikedPosts() {
+        // TODO 로그인 로직 구현 후 수정 (로그인한 유저만)
+        Long userId = 1L; // userId 반드시 필요함
+
+        List<PostResponseDto> likedPosts = postService.getLikedPostsByUserId(userId);
+
+        return ResponseEntity.ok(likedPosts);
     }
 
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/dao/PostDao.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/dao/PostDao.java
@@ -23,7 +23,7 @@ public interface PostDao {
     int countAllPosts();
 
     // 3. 게시글 단건 조회 (로그인 userId -> isLiked)
-    PostVo selectPostById(@Param("postId") long postId,@Param("userId") Long userId);
+    PostResponseDto selectPostById(@Param("postId") long postId, @Param("userId") Long userId);
 
     // 4. 게시글 수정
     int updatePost(PostVo postVo);

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/dto/PostResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/dto/PostResponseDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 
 // 단건 조회에서 내려줄 Dto
 @Data
-public class PostlResponseDto {
+public class PostResponseDto {
     private long postId;
     private long userId;
     private long bookId;

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostService.java
@@ -1,7 +1,6 @@
 package com.bookspace.domain.post.service;
 
 import java.util.List;
-import java.util.Map;
 
 import com.bookspace.domain.post.dto.PostPageResponseDto;
 import com.bookspace.domain.post.dto.PostRequestDto;
@@ -16,13 +15,13 @@ public interface PostService {
     PostPageResponseDto getAllPosts(int page, int size, Long userId);
 
     // 게시글 단건 조회
-    PostResponseDto getPostById(long postId);
+    PostResponseDto getPostById(long postId, Long userId);
 
     // 게시글 수정
     void updatePost(long postId, PostRequestDto requestDto, long loginUserId);
 
     // 게시글 삭제
-    void deletePost(long postId, long loginUserId);
+    void deletePost(long postId, Long loginUserId);
 
     // 조회수 증가
     void increaseViewCount(long postId);

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
@@ -2,7 +2,6 @@ package com.bookspace.domain.post.service;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.bookspace.domain.book.service.BookService;
 import com.bookspace.domain.post.dto.PostPageResponseDto;
@@ -75,10 +74,6 @@ public class PostServiceImpl implements PostService {
     public PostPageResponseDto getAllPosts(int page, int size, Long userId)
     {
 
-        // TODO 로그인 로직 구현 후 수정
-//        Long userId = 1L; // 로그인한 유저일 경우 (1번으로 테스트)
-//        // Long userId = null; // 로그인 하지 않았을 때
-
         int offset = page * size;
 
         Map<String, Object> params = new HashMap<>();
@@ -102,20 +97,17 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostResponseDto getPostById(long postId) {
+    @Transactional
+    public PostResponseDto getPostById(long postId, Long userId) {
 
-        // TODO 로그인 로직 구현 후 수정
-        //Long userId = 1L;
-        Long userId = null;
+        PostResponseDto responseDto = postDao.selectPostById(postId,userId);
 
-        PostVo postVo = postDao.selectPostById(postId,userId);
-
-        if(postVo == null){
+        if(responseDto == null){
             throw new IllegalArgumentException("Post not found with id: " + postId);
         }
 
         postDao.increaseViewCount(postId);
-        return convertToResponseDto(postVo);
+        return responseDto;
     }
 
     @Override
@@ -131,13 +123,13 @@ public class PostServiceImpl implements PostService {
 //        }
 
         // 1. 기존 게시글 조회
-        PostVo postVo = postDao.selectPostById(postId,loginUserId);
-        if(postVo == null){
+        PostResponseDto responseDto = postDao.selectPostById(postId,loginUserId);
+        if(responseDto == null){
             throw new IllegalArgumentException("Post not found with id: " + postId);
         }
 
         // 2. 작성자 userId 기준으로 권한 체크
-        if(postVo.getUserId() != loginUserId){
+        if(responseDto.getUserId() != loginUserId){
             throw new AccessDeniedException("Access denied 본인의 게시글만 수정할 수 있습니다");
         }
 
@@ -158,20 +150,20 @@ public class PostServiceImpl implements PostService {
 
 
     @Override
-    public void deletePost(long postId, long loginUserId) {
+    public void deletePost(long postId, Long loginUserId) {
 //        int deletedRows = postDao.deletePost(postId);
 //        if (deletedRows == 0) {
 //            throw new IllegalArgumentException("Post not found with id: " + postId);
 //        }
 
         // 1. 기존 게시글 조회
-        PostVo postVo = postDao.selectPostById(postId, loginUserId);
-        if(postVo == null){
+       PostResponseDto responseDto= postDao.selectPostById(postId, loginUserId);
+        if(responseDto == null){
             throw new IllegalArgumentException("Post not found with id: " + postId);
         }
 
         // 2. 작성자 체크
-        if(postVo.getUserId() != loginUserId){
+        if(responseDto.getUserId() != loginUserId){
             throw new AccessDeniedException("Access denied 본인의 게시글만 삭제할 수 있습니다.");
         }
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/vo/PostVo.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/vo/PostVo.java
@@ -15,5 +15,5 @@ public class PostVo {
     private int postViewCnt;
     private LocalDateTime postLastModified;
     private int likeCount;
-    private boolean isLiked;
+    private boolean liked;
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.bookspace.global.security.userdetails.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -77,11 +78,7 @@ public class SecurityConfig {
                                 "/auth/**",
                                 "/books/**"
                         ).permitAll() // 인증 없이 가능
-                        .requestMatchers(org.springframework.http.HttpMethod.POST, "/posts/**").authenticated()
-                        .requestMatchers(org.springframework.http.HttpMethod.PUT,  "/posts/**").authenticated()
-                        .requestMatchers(org.springframework.http.HttpMethod.DELETE,"/posts/**").authenticated()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/posts/**").permitAll()
-
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated() // 나머지 요청은 jwt가 필요함
                 )

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/jwt/JwtAuthenticationFilter.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/jwt/JwtAuthenticationFilter.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-
+@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
@@ -44,6 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     userDetails, null, userDetails.getAuthorities()
             );
+
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
         }
@@ -55,7 +56,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // Authorization 헤더에서 Bearer Token 추출
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-
         if(bearerToken != null && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }

--- a/BookSpace/backend/src/main/resources/mappers/PostMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/PostMapper.xml
@@ -63,14 +63,14 @@
             -- 로그인 유저 좋아요 여부
             CASE
                 WHEN #{userId} IS NULL THEN FALSE
-                ELSE (
-                    SELECT COUNT(*) > 0
+                WHEN EXISTS (
+                    SELECT 1
                     FROM post_like pl
                     WHERE pl.post_id = p.post_id
                       AND pl.user_id = #{userId}
-                )
-                END AS isLiked
-
+                ) THEN TRUE
+                ELSE FALSE
+                END AS liked
         FROM post p
                  JOIN book b ON p.book_id = b.book_id
                  JOIN user u ON p.user_id = u.user_id
@@ -104,39 +104,53 @@
 <!--    </select>-->
 
     <!-- 3. 단건 조회 -->
-    <select id="selectPostById" resultType="postVo">
-
+    <select id="selectPostById" resultType="postResponseDto">
         SELECT
-            p.post_id,
-            p.user_id,
-            p.book_id,
-            p.post_title,
-            p.post_content,
-            p.post_date,
-            p.post_view_cnt,
-            p.post_last_modified,
+            p.post_id            AS postId,
+            p.user_id            AS userId,
+            p.book_id            AS bookId,
 
-            -- 좋아요 개수
+            b.book_title         AS bookTitle,
+            b.book_author        AS bookAuthor,
+            b.book_image_url     AS bookImageUrl,
+
+            p.post_title         AS postTitle,
+            p.post_content       AS postContent,
+            p.post_date          AS postDate,
+            p.post_view_cnt      AS postViewCnt,
+            p.post_last_modified AS postLastModified,
+
+            u.user_nickname      AS userNickName,
+
+            -- 좋아요 수
             (SELECT COUNT(*)
              FROM post_like pl
-                      JOIN user u ON pl.user_id = u.user_id
-             WHERE pl.post_id = p.post_id
-               AND u.user_status = 'active') AS likeCount,
+             WHERE pl.post_id = p.post_id) AS likeCount,
 
-            -- 유저 좋아요 여부
+            -- 댓글 수
+            (SELECT COUNT(*)
+             FROM comment c
+             WHERE c.post_id = p.post_id) AS commentCount,
+
+            -- 로그인 유저 좋아요 여부
             CASE
                 WHEN #{userId} IS NULL THEN FALSE
-                ELSE (
-                    SELECT COUNT(*) > 0
+                WHEN EXISTS (
+                    SELECT 1
                     FROM post_like pl
                     WHERE pl.post_id = p.post_id
                       AND pl.user_id = #{userId}
-                )
-                END AS isLiked
+                ) THEN TRUE
+                ELSE FALSE
+                END AS liked
 
         FROM post p
+                 JOIN user u ON p.user_id = u.user_id
+                 JOIN book b ON p.book_id = b.book_id
         WHERE p.post_id = #{postId}
+
     </select>
+
 
 
 


### PR DESCRIPTION
## PR Summary

- **Type**: Edit
- **Scope**: BE(post, security)
- **Issue**: #79 / Refs #

---

## 작업 내용

**1. post 전체 조회 & 단일 조회 api에 선택적 인증(Optional Auth) 적용**
- 비로그인/로그인 유저 모두 게시물 전체/단일 조회 가능 (비로그인 유저 userId: null)
- 로그인 유저에게는 **내가 좋아요한 게시글 여부(liked)** 를 함께 제공 (로그인 유저 userId ← 토큰값)


**2. 게시물 조회 필드명 및 응답 타입 수정**
- 게시물 전체 / 단일 조회 필드명 통일
- 게시물 조회 응답 타입 수정: PostVo → PostResponseDto

---

## Changes

### Frontend

- N/A

### Backend

- **EndPoints**
    - `GET /posts` (optional: token)
        - 비로그인/로그인 공용 게시글 목록 조회 
        - 로그인 유저일 경우 liked 여부 포함
    - `GET /posts/{postId}` (optional: token)
        - 게시글 단건 조회
        - 로그인 유저일 경우 liked 여부 포함
- **Business Logic**
    - `@AuthenticationPrincipal CustomUserDetails` nullable 허용
    - 인증되지 않은 경우 userId = null로 처리
    - 로그인 유저 존재 시에만 좋아요 여부 판별
    - 조회 API는 public, 좋아요/삭제 등 액션은 인증 필수 구조 유지