### PR TITLE
[FE_Feat] 커뮤니티 뷰 기존 게시글 스크롤 위치 유지 및 Post 수정, 삭제 작업(#79)

### DIFF
--- a/BookSpace/frontend/src/api/postApi.js
+++ b/BookSpace/frontend/src/api/postApi.js
@@ -45,6 +45,26 @@ export const fetchPostDetail = async (postId) => {
   return res.data;
 };
 
+// [U] 게시글 수정
+export const updatePostApi = async (postId, payload) => {
+  const body = { ...payload };
+
+  Object.keys(body).forEach((key) => {
+    if (body[key] === "" || body[key] === null || body[key] === undefined) {
+      delete body[key];
+    }
+  });
+
+  const res = await httpClient.put(`/posts/${postId}`, body);
+  return res.data;
+};
+
+// [D] 게시글 삭제
+export const deletePostApi = async (postId) => {
+  const res = await httpClient.delete(`/posts/${postId}`);
+  return res.data;
+};
+
 // 게시글 좋아요
 export const postLikes = async (postId) => {
   console.log("post likes");

--- a/BookSpace/frontend/src/components/community/PostCard.vue
+++ b/BookSpace/frontend/src/components/community/PostCard.vue
@@ -2,6 +2,7 @@
 <template>
   <div
     class="flex justify-between w-full p-5 transition border shadow-sm cursor-pointer border-border rounded-xl bg-card hover:shadow-md"
+    :data-post-id="post.postId"
     @click="goToPostDetail"
   >
     <div class="flex flex-col justify-between">
@@ -99,7 +100,7 @@ import { useToast } from "@/composables/useToast";
 import { postLikes, deleteLikes } from "@/api/postApi";
 import { useMutation, useQueryClient } from "@tanstack/vue-query";
 import { useAuthStore } from "@/stores/authStore";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 const { toast } = useToast();
 
 const props = defineProps({
@@ -109,6 +110,7 @@ const props = defineProps({
   },
 });
 
+const route = useRoute();
 const router = useRouter();
 const authStore = useAuthStore();
 const queryClient = useQueryClient();
@@ -194,9 +196,20 @@ const toggleLike = async () => {
 };
 
 const goToPostDetail = () => {
+  // 현재 스크롤 위치를 저장해서 돌아올 때 위치 복원하기
+  sessionStorage.setItem(
+    "communityScroll",
+    JSON.stringify({
+      scrollY: window.scrollY,
+      postId: props.post.postId,
+    })
+  );
   router.push({
     name: "postDetail",
     params: { postId: props.post.postId },
+    query: {
+      ...route.query,
+    },
   });
 };
 </script>

--- a/BookSpace/frontend/src/router/index.js
+++ b/BookSpace/frontend/src/router/index.js
@@ -91,7 +91,7 @@ import BookDetailView from "@/views/BookDetailView";
 import CommunityView from "@/views/CommunityView";
 import PostDetailView from "@/views/PostDetailView";
 import ProfileView from "@/views/ProfileView";
-import PostCreateView from "@/views/PostCreateView";
+import PostCreateUpdateView from "@/views/PostCreateUpdateView";
 import SignInView from "../views/SignInView";
 import SignupView from "@/views/SignupView";
 
@@ -126,12 +126,12 @@ const router = createRouter({
         {
           path: "/community/create",
           name: "postCreate",
-          component: PostCreateView,
+          component: PostCreateUpdateView,
           meta: { requiresAuth: true },
         },
         // post detail
         {
-          path: "/community/:postId",
+          path: "/community/posts/:postId",
           name: "postDetail",
           component: PostDetailView,
           props: true,

--- a/BookSpace/frontend/src/views/CommunityView.vue
+++ b/BookSpace/frontend/src/views/CommunityView.vue
@@ -82,23 +82,24 @@ import Button from "../components/ui/Button.vue";
 import { PlusIcon } from "lucide-vue-next";
 import { ArrowUpIcon } from "@heroicons/vue/24/solid";
 import PostCard from "@/components/community/PostCard";
-import {
-  useInfiniteQuery,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/vue-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/vue-query";
 import { fetchPosts } from "../api/postApi.js";
-import { computed, onMounted, ref, onUnmounted, watch } from "vue";
-import { useRouter } from "vue-router";
+import { computed, onMounted, ref, onUnmounted, watch, nextTick } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import { useToast } from "@/composables/useToast";
 import { useAuthStore } from "@/stores/authStore";
 
 const authStore = useAuthStore();
+const route = useRoute();
 const router = useRouter();
 const { toast } = useToast();
-const queryClient = useQueryClient();
+
+// 1. 쿼리에서 목록 상태 복원 (스크롤 복원 위치)
+const page = computed(() => Number(route.query.page ?? 0));
+const keyword = computed(() => route.query.keyword ?? "");
 
 // 게시글 목록 경로: data.pages[0].content.posts
+// 2. 게시글 목록 조회
 const {
   data,
   fetchNextPage,
@@ -118,6 +119,23 @@ const {
   // onSuccess: (data) => {
   //   console.log(JSON.parse(JSON.stringify(data)));
   // },
+});
+
+// 스크롤 복원용 상태
+const pendingScroll = ref(null);
+const hasRestoredScroll = ref(false);
+const isRestoringScroll = ref(false);
+
+// 3. scroll 위치 복원
+onMounted(() => {
+  const stored = sessionStorage.getItem("communityScroll");
+  if (stored) {
+    try {
+      pendingScroll.value = JSON.parse(stored);
+    } catch (err) {
+      console.error("Failed to parse scroll state", err);
+    }
+  }
 });
 
 // 최신 게시글 감지용 쿼리 (첫 페이지만 주기적으로 조회)
@@ -228,4 +246,47 @@ const showLatestPosts = async () => {
 const scrollToTop = () => {
   window.scrollTo({ top: 0, behavior: "smooth" });
 };
+
+// 데이터 로드 후 저장된 스크롤 위치로 복원
+const restoreScrollIfNeeded = async () => {
+  if (
+    hasRestoredScroll.value ||
+    isRestoringScroll.value ||
+    !pendingScroll.value
+  )
+    return;
+
+  isRestoringScroll.value = true;
+  await nextTick();
+
+  let targetEl = null;
+  if (pendingScroll.value.postId) {
+    targetEl = document.querySelector(
+      `[data-post-id="${pendingScroll.value.postId}"]`
+    );
+  }
+
+  // 대상 게시글이 아직 렌더되지 않았으면 다음 페이지 불러오기
+  if (!targetEl && hasNextPage.value && !isFetchingNextPage.value) {
+    isRestoringScroll.value = false;
+    await fetchNextPage();
+    return;
+  }
+
+  const targetTop =
+    pendingScroll.value.scrollY ??
+    (targetEl ? targetEl.getBoundingClientRect().top + window.scrollY - 60 : 0);
+
+  window.scrollTo({ top: targetTop, behavior: "auto" });
+  hasRestoredScroll.value = true;
+  isRestoringScroll.value = false;
+  sessionStorage.removeItem("communityScroll");
+};
+
+watch(
+  () => [data.value?.pages?.length, isFetchingNextPage.value],
+  () => {
+    restoreScrollIfNeeded();
+  }
+);
 </script>

--- a/BookSpace/frontend/src/views/PostCreateUpdateView.vue
+++ b/BookSpace/frontend/src/views/PostCreateUpdateView.vue
@@ -1,9 +1,9 @@
-<!-- TODO 검색 기능 -->
+<!-- TODO 검색 기능: 책 검색 (알라딘 api 조회 후) -> isbn으로 서버에 보내기-->
 <!--TODO 스타일 수정  -->
 <template>
   <ViewHeader
-    title="게시글 작성"
-    description="책에 대한 소감을 남겨보세요."
+    :title="headerTitle"
+    :description="headerDescription"
     align="left"
     size="lg"
   />
@@ -19,7 +19,7 @@
         </div>
         <SearchInput
           v-model="isbn"
-          placeholder="책 제목 또는 ISBN을 검색하세요"
+          placeholder="책 제목을 검색하세요"
           @search="onSearch"
         />
       </div>
@@ -39,7 +39,6 @@
         <Textarea
           v-model="postContent"
           rows="10"
-          :class="textareaClasses"
           placeholder="책에 대한 생각이나 질문을 자유롭게 작성하세요"
           required
         />
@@ -60,10 +59,10 @@
           </Button>
           <Button
             type="submit"
-            :disabled="!isFormValid || isSubmitting"
+            :disabled="!isFormValid || isSubmitting || isEditLoading"
             :loading="isSubmitting"
           >
-            게시글 등록
+            {{ submitLabel }}
           </Button>
         </div>
       </div>
@@ -72,30 +71,34 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
-import { useRouter } from "vue-router";
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import ViewHeader from "@/components/common/ViewHeader.vue";
 import Button from "@/components/ui/Button.vue";
 import SearchInput from "../components/common/SearchInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Textarea from "@/components/ui/Textarea.vue";
-import { createPostApi } from "@/api/postApi";
-import { useMutation, useQueryClient } from "@tanstack/vue-query";
+import { createPostApi, fetchPostDetail, updatePostApi } from "@/api/postApi";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
 
 const router = useRouter();
+const route = useRoute();
 const queryClient = useQueryClient();
+
+const isEditMode = computed(() => route.query.mode === "edit");
+const postId = computed(() => route.query.postId);
+const preloadedPost =
+  route.state?.post &&
+  postId.value &&
+  String(route.state.post.postId) === String(postId.value)
+    ? route.state.post
+    : null;
 
 const isbn = ref("");
 const postTitle = ref("");
 const postContent = ref("");
 const errorMessage = ref("");
 const isSubmitting = ref(false);
-
-const textareaClasses =
-  "w-full rounded-md border border-[color:var(--border)] bg-[color:var(--background)] " +
-  "text-[color:var(--foreground)] px-3 py-2 text-sm shadow-xs transition outline-none " +
-  "placeholder:text-[color:var(--muted-foreground)] " +
-  "focus-visible:ring-[3px] focus-visible:ring-[color:var(--ring)]/50 focus-visible:border-[color:var(--ring)] min-h-[220px] resize-y leading-relaxed";
 
 const isFormValid = computed(() => {
   return (
@@ -104,6 +107,37 @@ const isFormValid = computed(() => {
     !!isbn.value.trim()
   );
 });
+
+const headerTitle = computed(() =>
+  isEditMode.value ? "게시글 수정" : "게시글 작성"
+);
+const headerDescription = computed(() =>
+  isEditMode.value
+    ? "게시글을 수정할 수 있습니다."
+    : "책에 대한 소감을 남겨보세요."
+);
+const submitLabel = computed(() =>
+  isEditMode.value ? "수정 완료" : "게시글 등록"
+);
+
+const { data: detailData, isLoading: isEditLoading } = useQuery({
+  queryKey: ["post", postId.value],
+  queryFn: () => fetchPostDetail(postId.value),
+  enabled: computed(() => isEditMode.value && !!postId.value),
+  initialData: () => (isEditMode.value ? preloadedPost : undefined),
+  staleTime: 0,
+});
+
+watch(
+  () => detailData.value,
+  (val) => {
+    if (!isEditMode.value || !val) return;
+    isbn.value = val.isbn || "";
+    postTitle.value = val.postTitle || "";
+    postContent.value = val.postContent || "";
+  },
+  { immediate: true }
+);
 
 const createPostMutation = useMutation({
   mutationFn: (payload) => createPostApi(payload),
@@ -116,6 +150,21 @@ const createPostMutation = useMutation({
     errorMessage.value =
       error?.response?.data?.message ||
       "게시글 등록에 실패했습니다. 잠시 후 다시 시도해주세요.";
+  },
+});
+
+const updatePostMutation = useMutation({
+  mutationFn: (payload) => updatePostApi(postId.value, payload),
+  onSuccess: async () => {
+    await queryClient.invalidateQueries({ queryKey: ["posts"] });
+    await queryClient.invalidateQueries({ queryKey: ["posts", "latest"] });
+    await queryClient.invalidateQueries({ queryKey: ["post", postId.value] });
+    router.push({ name: "postDetail", params: { postId: postId.value } });
+  },
+  onError: (error) => {
+    errorMessage.value =
+      error?.response?.data?.message ||
+      "게시글 수정에 실패했습니다. 잠시 후 다시 시도해주세요.";
   },
 });
 
@@ -137,11 +186,21 @@ const handleSubmit = async () => {
 
   isSubmitting.value = true;
   try {
-    await createPostMutation.mutateAsync({
-      isbn: trimmedIsbn,
-      postTitle: trimmedTitle,
-      postContent: trimmedContent,
-    });
+    // 게시글 수정
+    if (isEditMode.value && postId.value) {
+      await updatePostMutation.mutateAsync({
+        isbn: trimmedIsbn,
+        postTitle: trimmedTitle,
+        postContent: trimmedContent,
+      });
+    } else {
+      // 게시글 작성
+      await createPostMutation.mutateAsync({
+        isbn: trimmedIsbn,
+        postTitle: trimmedTitle,
+        postContent: trimmedContent,
+      });
+    }
   } finally {
     isSubmitting.value = false;
   }

--- a/BookSpace/frontend/src/views/PostDetailView.vue
+++ b/BookSpace/frontend/src/views/PostDetailView.vue
@@ -34,6 +34,42 @@
               </p>
             </div>
           </div>
+          <!-- 로그인한 유저가 게시글 작성 유저일 경우 three-dot 메뉴 -->
+          <div class="flex items-center gap-2">
+            <div v-if="isOwner" class="relative">
+              <button
+                type="button"
+                class="flex items-center justify-center w-8 h-8 rounded-full hover:bg-muted"
+                @click="toggleMenu"
+              >
+                <MoreVertical class="w-4 h-4 text-muted-foreground" />
+              </button>
+              <!-- ... 클릭 -> 메뉴 -->
+              <div
+                v-if="showMenu"
+                class="absolute right-0 z-10 w-20 h-auto p-3 mt-1 overflow-hidden border rounded-md shadow-md bg-card border-border"
+              >
+                <!-- 수정 버튼 -->
+                <button
+                  type="button"
+                  class="flex justify-center w-full px-3 py-3 mb-1 text-sm text-left hover:bg-muted"
+                  @mousedown.prevent
+                  @click="editPost"
+                >
+                  수정하기
+                </button>
+                <!-- 삭제버튼 -->
+                <button
+                  type="button"
+                  class="flex justify-center w-full px-3 py-2 text-sm text-left text-destructive hover:bg-muted"
+                  @mousedown.prevent
+                  @click="deletePost"
+                >
+                  삭제하기
+                </button>
+              </div>
+            </div>
+          </div>
         </header>
 
         <div class="space-y-4">
@@ -67,49 +103,47 @@
             </div>
             <Separator />
           </div>
-
-          <div
-            class="flex flex-wrap items-center gap-3 text-sm text-muted-foreground"
-          >
-            <button
-              type="button"
-              class="flex items-center gap-1 px-3 py-1 transition rounded-full group"
-              :class="
-                isLiked
-                  ? 'text-destructive bg-destructive/10'
-                  : 'hover:bg-muted'
-              "
-              :disabled="toggleLikeMutation.isPending.value"
-              @click="handleToggleLike"
-            >
-              <HeartIcon
-                class="w-4 h-4 transition-colors"
-                :class="
-                  isLiked
-                    ? 'text-destructive'
-                    : 'text-muted-foreground group-hover:text-destructive'
-                "
-              />
-              <span :class="isLiked ? 'font-semibold text-foreground' : ''">
-                {{ likeCount }}개의 좋아요
-              </span>
-            </button>
-            <span class="text-muted-foreground">|</span>
-            <div class="flex items-center gap-1">
-              <MessageSquare class="w-4 h-4" />
-              <span>{{ post.commentCount ?? 0 }}개의 댓글</span>
-            </div>
-            <span class="text-muted-foreground">|</span>
-            <div class="flex items-center gap-1">
-              <Eye class="w-4 h-4" />
-              <span>{{ post.postViewCnt ?? 0 }}회 조회</span>
-            </div>
-          </div>
         </div>
 
         <p class="leading-relaxed whitespace-pre-line text-foreground">
           {{ content }}
         </p>
+        <!-- 좋아요 & 댓굴 & 조회 -->
+        <div
+          class="flex items-center justify-end w-full gap-3 text-sm flex- text-muted-foreground"
+        >
+          <button
+            type="button"
+            class="flex items-center gap-1 px-3 py-1 transition rounded-full group"
+            :class="
+              isLiked ? 'text-destructive bg-destructive/10' : 'hover:bg-muted'
+            "
+            :disabled="toggleLikeMutation.isPending.value"
+            @click="handleToggleLike"
+          >
+            <HeartIcon
+              class="w-4 h-4 transition-colors"
+              :class="
+                isLiked
+                  ? 'text-destructive'
+                  : 'text-muted-foreground group-hover:text-destructive'
+              "
+            />
+            <span :class="isLiked ? 'font-semibold text-foreground' : ''">
+              {{ likeCount }}개의 좋아요
+            </span>
+          </button>
+          <span class="text-muted-foreground">|</span>
+          <div class="flex items-center gap-1">
+            <MessageSquare class="w-4 h-4" />
+            <span>{{ post.commentCount ?? 0 }}개의 댓글</span>
+          </div>
+          <span class="text-muted-foreground">|</span>
+          <div class="flex items-center gap-1">
+            <Eye class="w-4 h-4" />
+            <span>{{ post.postViewCnt ?? 0 }}회 조회</span>
+          </div>
+        </div>
       </article>
 
       <div v-if="isError" class="flex items-center gap-3 text-sm">
@@ -125,17 +159,22 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
-import { useRouter } from "vue-router";
+import { computed, onMounted, ref, watch, onActivated } from "vue";
+import { useRouter, onBeforeRouteUpdate } from "vue-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
-import ViewHeader from "@/components/common/ViewHeader.vue";
 import Button from "@/components/ui/Button.vue";
 import { useToast } from "@/composables/useToast";
 import Separator from "@/components/ui/Separator.vue";
-import { deleteLikes, fetchPostDetail, postLikes } from "@/api/postApi";
-import { MessageSquare, Eye, ArrowLeft } from "lucide-vue-next";
+import {
+  deleteLikes,
+  deletePostApi,
+  fetchPostDetail,
+  postLikes,
+} from "@/api/postApi";
+import { MessageSquare, Eye, ArrowLeft, MoreVertical } from "lucide-vue-next";
 import { HeartIcon } from "@heroicons/vue/24/solid";
 import { useAuthStore } from "@/stores/authStore";
+import { useUserStore } from "@/stores/userStore";
 
 const { toast } = useToast();
 
@@ -149,6 +188,7 @@ const props = defineProps({
 const router = useRouter();
 const queryClient = useQueryClient();
 const authStore = useAuthStore();
+const userStore = useUserStore();
 
 const { data, isLoading, isError, refetch } = useQuery({
   queryKey: ["post", props.postId],
@@ -158,8 +198,14 @@ const { data, isLoading, isError, refetch } = useQuery({
 });
 
 const post = computed(() => data.value);
+const viewAdjusted = ref(false);
 const likeCount = computed(() => post.value?.likeCount ?? 0);
 const isLiked = computed(() => !!post.value?.liked);
+const me = computed(() => userStore.me);
+const isOwner = computed(() => {
+  if (!authStore.isLoggedIn || !post.value || !me.value) return false;
+  return String(me.value.userId) === String(post.value.userId);
+});
 
 const formattedDate = computed(() => {
   const dateString = post.value?.postDate;
@@ -177,7 +223,75 @@ const defaultProfile = "/default-profile.png";
 const defaultBook = "/default-book.png";
 
 const goBack = () => {
-  router.back();
+  router.push({
+    name: "community",
+    query: router.currentRoute.value.query,
+  });
+};
+
+const showMenu = ref(false);
+const toggleMenu = () => {
+  showMenu.value = !showMenu.value;
+};
+const closeMenu = () => {
+  showMenu.value = false;
+};
+
+const syncPostToLists = (nextPost) => {
+  if (!nextPost) return;
+
+  const updateCache = (queryKey) => {
+    const cache = queryClient.getQueryData(queryKey);
+    if (!cache?.pages) return;
+
+    const updatedPages = cache.pages.map((page) => {
+      const updatedPosts = page.posts?.map((p) =>
+        String(p.postId) === String(nextPost.postId) ? { ...p, ...nextPost } : p
+      );
+      return { ...page, posts: updatedPosts };
+    });
+
+    queryClient.setQueryData(queryKey, { ...cache, pages: updatedPages });
+  };
+
+  updateCache(["posts"]);
+  updateCache(["posts", "latest"]);
+};
+
+const updatePostInLists = (nextLiked) => {
+  const updateCache = (queryKey) => {
+    const cache = queryClient.getQueryData(queryKey);
+    if (!cache?.pages) return cache;
+
+    const updatedPages = cache.pages.map((page) => {
+      const updatedPosts = page.posts?.map((p) => {
+        if (String(p.postId) !== String(props.postId)) return p;
+        const nextCount = Math.max(
+          0,
+          (p.likeCount ?? 0) + (nextLiked ? 1 : -1)
+        );
+        return { ...p, liked: nextLiked, likeCount: nextCount };
+      });
+      return { ...page, posts: updatedPosts };
+    });
+
+    queryClient.setQueryData(queryKey, { ...cache, pages: updatedPages });
+    return cache;
+  };
+
+  const previousPosts = updateCache(["posts"]);
+  const previousLatest = updateCache(["posts", "latest"]);
+
+  return { previousPosts, previousLatest };
+};
+
+const rollbackPostInLists = (previousPosts, previousLatest) => {
+  if (previousPosts) {
+    queryClient.setQueryData(["posts"], previousPosts);
+  }
+  if (previousLatest) {
+    queryClient.setQueryData(["posts", "latest"], previousLatest);
+  }
 };
 
 const toggleLikeMutation = useMutation({
@@ -185,6 +299,8 @@ const toggleLikeMutation = useMutation({
     nextLiked ? postLikes(props.postId) : deleteLikes(props.postId),
   onMutate: async ({ nextLiked }) => {
     await queryClient.cancelQueries({ queryKey: ["post", props.postId] });
+    await queryClient.cancelQueries({ queryKey: ["posts"] });
+    await queryClient.cancelQueries({ queryKey: ["posts", "latest"] });
     const previous = queryClient.getQueryData(["post", props.postId]);
 
     queryClient.setQueryData(["post", props.postId], (old) => {
@@ -196,15 +312,20 @@ const toggleLikeMutation = useMutation({
       return { ...old, liked: nextLiked, likeCount: updatedCount };
     });
 
-    return { previous };
+    const listSnapshots = updatePostInLists(nextLiked);
+
+    return { previous, ...listSnapshots };
   },
   onError: (_err, _vars, ctx) => {
     if (ctx?.previous) {
       queryClient.setQueryData(["post", props.postId], ctx.previous);
     }
+    rollbackPostInLists(ctx?.previousPosts, ctx?.previousLatest);
   },
   onSettled: () => {
     queryClient.invalidateQueries({ queryKey: ["post", props.postId] });
+    queryClient.invalidateQueries({ queryKey: ["posts"] });
+    queryClient.invalidateQueries({ queryKey: ["posts", "latest"] });
   },
 });
 
@@ -227,4 +348,60 @@ const handleToggleLike = async () => {
   const nextLiked = !isLiked.value;
   await toggleLikeMutation.mutateAsync({ nextLiked });
 };
+
+const editPost = () => {
+  closeMenu();
+  router.push({
+    name: "postCreate",
+    query: { mode: "edit", postId: props.postId },
+    state: { post: post.value },
+  });
+};
+
+const deletePostMutation = useMutation({
+  mutationFn: () => deletePostApi(props.postId),
+  onSuccess: async () => {
+    await queryClient.invalidateQueries({ queryKey: ["posts"] });
+    await queryClient.invalidateQueries({ queryKey: ["posts", "latest"] });
+    router.push({ name: "community" });
+  },
+});
+
+const deletePost = async () => {
+  closeMenu();
+  if (!confirm("게시글을 삭제하시겠습니까?")) return;
+  await deletePostMutation.mutateAsync();
+};
+
+onMounted(async () => {
+  if (authStore.isLoggedIn && !me.value) {
+    try {
+      await userStore.fetchMyInfo();
+    } catch (err) {
+      console.error("[POST] failed to fetch my info", err);
+    }
+  }
+  viewAdjusted.value = false;
+});
+
+onActivated(() => {
+  viewAdjusted.value = false;
+});
+
+watch(
+  () => post.value?.postViewCnt,
+  (val) => {
+    if (!post.value || viewAdjusted.value) return;
+    const nextCount = (val ?? 0) + 1;
+    const nextPost = { ...post.value, postViewCnt: nextCount };
+    queryClient.setQueryData(["post", props.postId], nextPost);
+    syncPostToLists(nextPost);
+    viewAdjusted.value = true;
+  },
+  { immediate: true }
+);
+
+onBeforeRouteUpdate(() => {
+  viewAdjusted.value = false;
+});
 </script>


### PR DESCRIPTION
## PR Summary

- **Type**: feat
- **Scope**: FE(post)
- **Issue**:  #79 / Refs #

---

## 작업 내용

**1. Post Update & Delete**

- 로그인 유저가 게시글 작성자일 경우에만 상세 화면에서 수정/삭제 메뉴 UI 노출 및 기능 구현
- 게시글 작성 화면(PostCreateView)을 수정 모드에서도 재사용하도록 로직 확장(PostCreateUpdateView로 수정함)

**2. Community View 목록 상태(page/search/scroll)를 query로 유지해 복귀 시 위치 복원**

- Community View (**게시글 목록) → 특정 게시글 상세 조회 / 수정 / 삭제 작업 후 → Community View 복귀 시 스크롤 위치 유지

**3. 상세 조회 시 조회수(postViewCnt) 로컬 캐시 보정 처리**

- postViewCnt는 서버에서 증가시킴
- vue-query 캐시를 활용해 상세/목록 간 조회수 상태 일관성 유지

---

## Changes

### Frontend

- **UI/UX**
    - 게시글 상세 화면에 작성자 전용 three-dot 메뉴(수정/삭제) 추가
    - 게시글 수정 시 기존 작성 UI 재사용
    - 목록 → 상세 → 목록 이동 시 사용자가 보던 위치 유지
- **State / Data Flow**
    - 게시글 수정 시 route state 기반 초기 데이터 주입
    - Community 목록 상태를 URL query(page, keyword, scroll)로 관리
    - 상세 조회 시 조회수 로컬 캐시 보정으로 화면 간 값 불일치 제거
- **API Integration**
    - 게시글 수정 시 `updatePostApi` 연동
    - 게시글 삭제 시 성공 후 목록 캐시 invalidate 처리
- **Routing**
    - 상세 진입 시 목록 query 유지
    - 상세 화면 “목록으로” 버튼을 `router.back()` 대신 명시적 community 이동으로 변경
- **Edge Cases / Errors**
    - 로그인 상태가 아닐 경우 수정/삭제/좋아요 액션 제한
    - 수정 화면 진입 시 preload 데이터가 없을 경우 API fallback

---

### Backend

- N/A

---

## How to Test

1. Community 게시글 목록 진입
2. 특정 게시글 클릭 → 상세 페이지 이동
3. 작성자 계정으로 로그인 시 수정/삭제 버튼 노출 확인  (three-dots 메뉴 모양)
4. 수정 버튼 클릭 → 게시글 작성 화면이 수정 모드로 열리는지 확인
5. 상세 페이지 진입 후 “목록으로” 클릭 → 기존 보던 목록 위치/스크롤이 유지되는지 확인

**Expected**

- 작성자에게만 수정/삭제 버튼 노출
- 게시글 수정 시 기존 작성 UI 재사용
- 상세/목록 간 조회수 값 일관성 유지
- 상세 → 목록 이동 시 기존 위치 복원

---