### PR TITLE
[FE_Feat] 게시글 상세페이지 댓글 섹션 UI 작성 및  댓글 CREATE, READ 기능 구현(#100)

### DIFF
--- a/BookSpace/frontend/src/api/postApi.js
+++ b/BookSpace/frontend/src/api/postApi.js
@@ -2,7 +2,10 @@
 
 import httpClient from "./httpClient";
 
-// [C] 게시글 생성
+/**
+ * [C] 게시글 생성
+ * @param {*} payload
+ */
 export const createPostApi = async (payload) => {
   // payload: { userId, bookId?, isbn?, postTitle, postContent }
   const body = { ...payload };
@@ -18,7 +21,11 @@ export const createPostApi = async (payload) => {
   return res.data;
 };
 
-// [R] 게시글 전체 조회 (페이징)
+/**
+ *  [R] 게시글 전체 조회 (페이징)
+ * @param {*} param0
+ * @returns
+ */
 export const fetchPosts = async ({ pageParam = 0 }) => {
   const res = await httpClient.get("/posts", {
     params: {
@@ -39,13 +46,22 @@ export const fetchPosts = async ({ pageParam = 0 }) => {
   };
 };
 
-// [R] 게시글 단건 조회
+/**
+ * [R] 게시글 단건 조회
+ * @param {*} postId
+ * @returns
+ */
 export const fetchPostDetail = async (postId) => {
   const res = await httpClient.get(`/posts/${postId}`);
   return res.data;
 };
 
-// [U] 게시글 수정
+/**
+ * [U] 게시글 수정
+ * @param {*} postId
+ * @param {*} payload
+ * @returns
+ */
 export const updatePostApi = async (postId, payload) => {
   const body = { ...payload };
 
@@ -59,22 +75,64 @@ export const updatePostApi = async (postId, payload) => {
   return res.data;
 };
 
-// [D] 게시글 삭제
+/**
+ * [D] 게시글 삭제
+ * @param {*} postId
+ * @returns
+ */
 export const deletePostApi = async (postId) => {
   const res = await httpClient.delete(`/posts/${postId}`);
   return res.data;
 };
 
-// 게시글 좋아요
+// -------------------------- 게시글 좋아요 --------------------------
+/**
+ * 게시글 좋아요
+ * @param {*} postId
+ * @returns
+ */
 export const postLikes = async (postId) => {
   console.log("post likes");
   const res = await httpClient.post(`/posts/${postId}/like`);
   return res.data;
 };
 
-// 게시글 좋아요 취소
+/**
+ * 게시글 좋아요 취소
+ * @param {*} postId
+ * @returns
+ */
 export const deleteLikes = async (postId) => {
   console.log("post likes non nonono");
   const res = await httpClient.delete(`/posts/${postId}/like`);
+  return res.data;
+};
+
+// -------------------------- 게시글 댓글  --------------------------
+/**
+ * [R] 댓글 목록 조회 (대댓글 포함)
+ * @param {*} postId
+ * @returns
+ */
+export const fetchCommentsApi = async (postId) => {
+  const res = await httpClient.get(`/posts/${postId}/comments`);
+  return res.data;
+};
+
+/**
+ * [C] 댓글 작성 (parentCommentId 없으면 일반 댓글)
+ * @param {*} postId
+ * @param {*} payload
+ * @returns
+ */
+export const createCommentApi = async (postId, payload) => {
+  const body = { ...payload };
+  Object.keys(body).forEach((key) => {
+    if (body[key] === "" || body[key] === null || body[key] === undefined) {
+      delete body[key];
+    }
+  });
+
+  const res = await httpClient.post(`/posts/${postId}/comments`, body);
   return res.data;
 };

--- a/BookSpace/frontend/src/components/common/UserProfileImg.vue
+++ b/BookSpace/frontend/src/components/common/UserProfileImg.vue
@@ -1,0 +1,54 @@
+<template>
+  <div
+    class="overflow-hidden rounded-full bg-muted text-foreground flex items-center justify-center"
+    :class="[sizeClass, className]"
+    aria-hidden="true"
+  >
+    <img
+      v-if="src"
+      :src="src"
+      :alt="alt"
+      class="object-cover w-full h-full"
+      @error="onError"
+    />
+    <span v-else class="text-sm font-semibold">{{ initials }}</span>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from "vue";
+
+const props = defineProps({
+  src: {
+    type: String,
+    default: "",
+  },
+  name: {
+    type: String,
+    default: "",
+  },
+  alt: {
+    type: String,
+    default: "user profile",
+  },
+  sizeClass: {
+    type: String,
+    default: "w-10 h-10",
+  },
+  className: {
+    type: String,
+    default: "",
+  },
+});
+
+const hasError = ref(false);
+
+const onError = () => {
+  hasError.value = true;
+};
+
+const initials = computed(() => {
+  if (hasError.value || !props.name) return "유저";
+  return props.name.trim().slice(0, 2) || "유저";
+});
+</script>

--- a/BookSpace/frontend/src/components/community/CommentItem.vue
+++ b/BookSpace/frontend/src/components/community/CommentItem.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="space-y-3">
+    <div class="flex-col items-start gap-3">
+      <div class="flex items-center gap-4 mb-2">
+        <UserProfileImg :name="comment.userNickname" />
+        <p class="text-sm font-semibold text-foreground">
+          {{ comment.userNickname }}
+        </p>
+      </div>
+
+      <div class="flex justify-between space-y-2">
+        <!-- 댓글 내용 & 날짜 -->
+        <div>
+          <p
+            class="text-sm leading-relaxed whitespace-pre-line text-foreground"
+          >
+            {{ comment.commentContent }}
+          </p>
+          <p class="text-xs text-muted-foreground">{{ formattedDate }}</p>
+        </div>
+        <!-- 답글 작성 버튼 -->
+        <button
+          v-if="isParent"
+          class="text-xs text-primary hover:underline"
+          type="button"
+          @click="$emit('reply', comment.commentId)"
+        >
+          답글
+        </button>
+      </div>
+      <!-- 답글 작성 Textarea -->
+      <slot name="replyArea" />
+    </div>
+
+    <div
+      v-if="comment.replies?.length"
+      class="pl-12 space-y-3 border-l border-border"
+    >
+      <CommentItem
+        v-for="reply in comment.replies"
+        :key="reply.commentId"
+        :comment="reply"
+        @reply="$emit('reply', $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import UserProfileImg from "@/components/common/UserProfileImg.vue";
+
+defineOptions({ name: "CommentItem" });
+
+const props = defineProps({
+  comment: {
+    type: Object,
+    required: true,
+  },
+});
+
+defineEmits(["reply"]);
+
+const formattedDate = computed(() => {
+  if (!props.comment.commentDate) return "";
+  const date = new Date(props.comment.commentDate);
+  return date.toLocaleString("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+});
+
+const isParent = computed(() => props.comment.parentCommentId === null);
+</script>

--- a/BookSpace/frontend/src/components/community/CommentsSection.vue
+++ b/BookSpace/frontend/src/components/community/CommentsSection.vue
@@ -1,0 +1,255 @@
+<template>
+  <section class="p-6 mt-8 space-y-6 border rounded-xl border-border bg-card">
+    <!-- 댓글 & 댓글 개수 -->
+    <div class="flex items-center justify-between">
+      <h3 class="text-lg font-semibold text-foreground">
+        댓글 {{ commentCount }}
+      </h3>
+    </div>
+
+    <!-- 로그인 유저 댓글 작성 TextArea -->
+    <div v-if="authStore.isLoggedIn" class="space-y-3">
+      <label class="text-sm font-semibold text-foreground">댓글 작성</label>
+      <Textarea
+        v-model="commentText"
+        rows="3"
+        placeholder="댓글을 입력하세요"
+      />
+      <div class="flex justify-end gap-2">
+        <Button
+          size="lg"
+          :disabled="isSubmitting || !commentText.trim()"
+          @click="submitComment"
+        >
+          등록
+        </Button>
+      </div>
+      <p v-if="errorMessage" class="text-sm text-destructive">
+        {{ errorMessage }}
+      </p>
+    </div>
+
+    <!-- 비로그인 유저 UI (로그인 페이지 로그인 후 -> 해당 게시물 상세 조회 페이지로 이동) -->
+    <div
+      v-else
+      class="p-4 text-sm border rounded-lg bg-muted/40 border-border text-muted-foreground"
+    >
+      <p class="mb-2">댓글 작성은 로그인 후 이용할 수 있습니다.</p>
+
+      <!-- 로그인 페이지 이동 링크 -->
+      <button
+        type="button"
+        class="font-medium text-primary hover:underline"
+        @click="goToLogin"
+      >
+        로그인 하러 가기 →
+      </button>
+    </div>
+
+    <!-- 댓글 조회 -->
+    <div v-if="isLoading" class="py-4 text-sm text-muted-foreground">
+      댓글을 불러오는 중입니다...
+    </div>
+    <div v-else-if="isError" class="py-4 text-sm text-destructive">
+      댓글을 불러오는 데 실패했습니다. 잠시 후 다시 시도해주세요.
+    </div>
+    <div v-else-if="comments?.length" class="space-y-5">
+      <CommentItem
+        v-for="comment in comments"
+        :key="comment.commentId"
+        :comment="comment"
+        @reply="activateReply"
+      >
+        <template #replyArea v-if="replyTargetId === comment.commentId">
+          <div
+            class="p-4 mt-2 space-y-3 border rounded-lg bg-muted/40 border-border"
+          >
+            <div
+              class="flex items-center justify-between text-sm text-muted-foreground"
+            >
+              <span>답글 작성</span>
+            </div>
+            <Textarea
+              v-model="replyText"
+              rows="3"
+              placeholder="답글을 입력하세요"
+            />
+            <div class="flex justify-end gap-3">
+              <button
+                class="text-xs text-primary hover:underline"
+                variant="outline"
+                size="sm"
+                @click="cancelReply"
+                :disabled="isSubmitting"
+              >
+                취소
+              </button>
+              <button
+                class="text-xs text-primary hover:underline"
+                size="sm"
+                :disabled="isSubmitting || !replyText.trim()"
+                @click="submitReply"
+              >
+                등록
+              </button>
+            </div>
+          </div>
+        </template>
+      </CommentItem>
+    </div>
+    <div v-else class="py-4 text-sm text-muted-foreground">
+      아직 댓글이 없습니다. 첫 댓글을 남겨보세요.
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
+import Button from "@/components/ui/Button.vue";
+import Textarea from "@/components/ui/Textarea.vue";
+import CommentItem from "./CommentItem.vue";
+import { createCommentApi, fetchCommentsApi } from "@/api/postApi";
+import { useAuthStore } from "@/stores/authStore";
+import { useToast } from "@/composables/useToast";
+
+const props = defineProps({
+  postId: {
+    type: [String, Number],
+    required: true,
+  },
+});
+
+const authStore = useAuthStore();
+const router = useRouter();
+const queryClient = useQueryClient();
+const { toast } = useToast();
+
+const commentText = ref("");
+const replyText = ref("");
+const replyTargetId = ref(null);
+const errorMessage = ref("");
+const isSubmitting = ref(false);
+
+const {
+  data: commentData,
+  isLoading,
+  isError,
+  refetch,
+} = useQuery({
+  queryKey: ["comments", props.postId],
+  queryFn: () => fetchCommentsApi(props.postId),
+});
+
+const comments = computed(() => commentData.value || []);
+
+const commentCount = computed(() => {
+  const countReplies = (items = []) =>
+    items.reduce((acc, cur) => acc + 1 + countReplies(cur.replies || []), 0);
+  return countReplies(comments.value);
+});
+
+const resetForm = () => {
+  commentText.value = "";
+  replyText.value = "";
+  replyTargetId.value = null;
+  errorMessage.value = "";
+};
+
+const activateReply = (commentId) => {
+  replyTargetId.value = commentId;
+  replyText.value = "";
+  errorMessage.value = "";
+};
+
+const cancelReply = () => {
+  replyTargetId.value = null;
+  replyText.value = "";
+};
+
+const ensureAuth = () => {
+  if (authStore.isLoggedIn) return true;
+  const redirectPath = router.resolve({
+    name: "postDetail",
+    params: { postId: props.postId },
+  }).path;
+  router.push({
+    name: "signin",
+    query: { redirect: redirectPath },
+  });
+  toast({
+    title: "로그인이 필요한 서비스입니다.",
+    description: "댓글을 작성하려면 로그인해주세요.",
+  });
+  return false;
+};
+
+/**
+ * 비유저 로그인 로그인 페이지 이동
+ */
+const goToLogin = () => {
+  const redirectPath = router.resolve({
+    name: "postDetail",
+    params: { postId: props.postId },
+  }).path;
+
+  router.push({
+    name: "signin",
+    query: { redirect: redirectPath },
+  });
+};
+
+// comment Section -> post detail view : 게시글 상세 조회 조회 수 없데이트 emit
+const emit = defineEmits(["comment-changed"]);
+
+const createCommentMutation = useMutation({
+  mutationFn: (payload) => createCommentApi(props.postId, payload),
+  onSuccess: async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ["comments", props.postId],
+    });
+    emit("comment-changed", { type: "create" });
+    await refetch();
+  },
+  onError: (err) => {
+    errorMessage.value =
+      err?.response?.data?.message ||
+      "댓글 등록에 실패했습니다. 잠시 후 다시 시도해주세요.";
+  },
+});
+
+const submitComment = async () => {
+  if (!ensureAuth()) return;
+  const content = commentText.value.trim();
+  if (!content) return;
+  isSubmitting.value = true;
+  errorMessage.value = "";
+  try {
+    await createCommentMutation.mutateAsync({
+      commentContent: content,
+    });
+    commentText.value = "";
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+
+const submitReply = async () => {
+  if (!ensureAuth()) return;
+  const content = replyText.value.trim();
+  if (!content || !replyTargetId.value) return;
+  isSubmitting.value = true;
+  errorMessage.value = "";
+  try {
+    await createCommentMutation.mutateAsync({
+      commentContent: content,
+      parentCommentId: replyTargetId.value,
+    });
+    replyText.value = "";
+    replyTargetId.value = null;
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+</script>

--- a/BookSpace/frontend/src/components/community/PostCard.vue
+++ b/BookSpace/frontend/src/components/community/PostCard.vue
@@ -8,10 +8,10 @@
     <div class="flex flex-col justify-between">
       <!-- 작성자 정보 -->
       <div class="flex items-center gap-3 mb-4">
-        <img
-          :src="post.userProfileImage || defaultProfile"
-          class="object-cover w-10 h-10 rounded-full"
-          alt="profile"
+        <UserProfileImg
+          :src="post.userProfileImage"
+          :name="post.userNickName"
+          sizeClass="w-10 h-10"
         />
         <div>
           <p class="font-medium text-foreground">{{ post.userNickName }}</p>
@@ -101,6 +101,7 @@ import { postLikes, deleteLikes } from "@/api/postApi";
 import { useMutation, useQueryClient } from "@tanstack/vue-query";
 import { useAuthStore } from "@/stores/authStore";
 import { useRoute, useRouter } from "vue-router";
+import UserProfileImg from "@/components/common/UserProfileImg.vue";
 const { toast } = useToast();
 
 const props = defineProps({
@@ -116,7 +117,6 @@ const authStore = useAuthStore();
 const queryClient = useQueryClient();
 
 // TODO 기본 이미지
-const defaultProfile = "/default-profile.png";
 const defaultBook = "/default-book.png";
 
 // 날짜 포맷

--- a/BookSpace/frontend/src/views/PostDetailView.vue
+++ b/BookSpace/frontend/src/views/PostDetailView.vue
@@ -20,10 +20,10 @@
       <article class="p-6 space-y-5 border shadow-sm rounded-xl bg-card">
         <header class="flex items-start justify-between gap-4">
           <div class="flex items-center gap-3">
-            <img
-              :src="post.userProfileImage || defaultProfile"
-              alt="작성자 프로필"
-              class="object-cover w-12 h-12 rounded-full"
+            <UserProfileImg
+              :src="post.userProfileImage"
+              :name="post.userNickName"
+              sizeClass="w-12 h-12"
             />
             <div>
               <p class="font-semibold text-foreground">
@@ -146,6 +146,13 @@
         </div>
       </article>
 
+      <!-- 댓글 섹션 -->
+      <CommentsSection
+        v-if="post"
+        :post-id="post.postId"
+        @comment-changed="handleCommentChanged"
+      />
+
       <div v-if="isError" class="flex items-center gap-3 text-sm">
         <span class="text-destructive"
           >최신 정보를 불러오는 데 실패했습니다.</span
@@ -175,6 +182,8 @@ import { MessageSquare, Eye, ArrowLeft, MoreVertical } from "lucide-vue-next";
 import { HeartIcon } from "@heroicons/vue/24/solid";
 import { useAuthStore } from "@/stores/authStore";
 import { useUserStore } from "@/stores/userStore";
+import CommentsSection from "@/components/community/CommentsSection.vue";
+import UserProfileImg from "@/components/common/UserProfileImg.vue";
 
 const { toast } = useToast();
 
@@ -404,4 +413,25 @@ watch(
 onBeforeRouteUpdate(() => {
   viewAdjusted.value = false;
 });
+
+/**
+ * 댓글 변경 이벤트 핸들러
+ */
+const handleCommentChanged = ({ type }) => {
+  if (!post.value) return;
+
+  // 댓글 수 변화
+  const delta = type === "create" ? 1 : type === "delete" ? -1 : 0; // update는 변화 없음
+  if (delta == 0) return;
+
+  const nextCount = Math.max(0, (post.value.commentCount ?? 0) + delta);
+
+  const nextPost = { ...post.value, commentCount: nextCount };
+
+  // 상세 조회 캐시 즉시 반영
+  queryClient.setQueryData(["post", props.postId], nextPost);
+
+  // 목록 캐시도 동기화
+  syncPostToLists(nextPost);
+};
 </script>


### PR DESCRIPTION
## PR Summary

- **Type**: feat
- **Scope**: FE(comment)
- **Issue**:  #100 / Refs #

---

## 작업 내용

### Frontend

**1. 댓글 Create & Read (PostDetailView > CommentSection)**
- 댓글 UI 구현 (components > community > CommentSection)
- 댓글 입력 TextArea 로그인 여부에 따른 분기 (비로그인 유저: 로그인 페이지 이동 -> 로그인 성공 후 해당 postId의 상세 조회 페이지 리다이렉트 -> 댓글 작성)
- 댓글 CRUD 시 요청 성공 후 PostDetailView > commentCount 즉시 업데이트( (immediata change after success)

**2. 공통 컴포넌트**
- 유저 프로필 (components > common > UserProfileImg)

### Backend

- N/A

---

## How to Test

1. 게시글 상세 페이지 진입
2. 댓글 목록이 최신순으로 조회되는지 확인
3. 댓글 작성 후 즉시 목록에 반영되는지 확인 (PostDetailView 조회수도 같이 업데이트됨)
4. 비로그인 / 로그인 유저 댓글 작성 가능 여부 체크