### PR TITLE
[BE_Edit] Comment Domain 대댓글 스키마 확장에 따른 조회 응답 개선 (#100)

### DIFF
--- a/BookSpace/backend/.idea/sqldialects.xml
+++ b/BookSpace/backend/.idea/sqldialects.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="SqlDialectMappings">
     <file url="file://$PROJECT_DIR$/src/main/resources/mappers/BookMapper.xml" dialect="MySQL" />
+    <file url="file://$PROJECT_DIR$/src/main/resources/mappers/CommentMapper.xml" dialect="MySQL" />
     <file url="file://$PROJECT_DIR$/src/main/resources/mappers/PostLikeMapper.xml" dialect="MySQL" />
     <file url="file://$PROJECT_DIR$/src/main/resources/mappers/PostMapper.xml" dialect="MySQL" />
     <file url="file://$PROJECT_DIR$/src/main/resources/mappers/ReviewMapper.xml" dialect="MySQL" />

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/comment/controller/CommentController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/comment/controller/CommentController.java
@@ -17,7 +17,7 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    // [C] 댓글 생성 (Create)
+    // [C] 댓글 / 대댓글 생성 (Create)
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<String> createComment(
             @PathVariable("postId") long postId,
@@ -43,7 +43,8 @@ public class CommentController {
 
     // [R] - userId 특정 유저가 작성한 댓글 전체 조회 : 마이페이지에서 유저가 자신이 남긴 모든 댓글 목록 불러오기
     @GetMapping ("comments/user/{userId}")
-    public ResponseEntity<List<CommentResponseDto>> getCommentsByUserId(@PathVariable long userId){
+    public ResponseEntity<List<CommentResponseDto>> getCommentsByUserId(@AuthenticationPrincipal CustomUserDetails user){
+        long userId = user.getUserId();
         return ResponseEntity.ok(commentService.getCommentByUserId(userId));
     }
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/comment/dao/CommentDao.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/comment/dao/CommentDao.java
@@ -12,7 +12,7 @@ public interface CommentDao {
     // 1. [C] 댓글 등록
     int insertComment(CommentVo commentVo);
 
-    // 2. [R] 특정 postId의 모든 댓글 조회
+    // 2. [R] 특정 postId의 모든 댓글 조회 (댓글 + 대댓글)
     List<CommentResponseDto> selectCommentsByPostId(@Param("postId") long postId);
 
     // 3. [R] commentId로 단건 조회

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/comment/dto/CommentRequestDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/comment/dto/CommentRequestDto.java
@@ -5,6 +5,6 @@ import lombok.Data;
 @Data
 public class CommentRequestDto {
 
-    private long userId;
+    private Long parentCommentId; // 일반 댓글이면 null
     private String commentContent;
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/comment/dto/CommentResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/comment/dto/CommentResponseDto.java
@@ -3,13 +3,18 @@ package com.bookspace.domain.comment.dto;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 public class CommentResponseDto {
     private long commentId;
     private long postId;
     private long userId;
+    private String userNickname;
+    private Long parentCommentId;
     private String commentContent;
     private LocalDateTime commentDate;
     private LocalDateTime commentLastModified;
+    private List<CommentResponseDto> replies = new ArrayList<>();// 대댓글 목록 (depth=1)
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/comment/service/CommentServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/comment/service/CommentServiceImpl.java
@@ -8,7 +8,11 @@ import com.bookspace.domain.common.validation.ValidatePostExists;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -20,9 +24,26 @@ public class CommentServiceImpl implements CommentService {
     @Override
     @ValidatePostExists(postId = "#postId")
     public void createComment(long postId, CommentRequestDto commentDto, long loginUserId) {
+        // 대댓글일 경우 부모 댓글 검증
+        if(commentDto.getParentCommentId()!=null){
+            CommentResponseDto parent = commentDao.selectCommentById(commentDto.getParentCommentId());
+            if(parent == null){
+                throw new IllegalArgumentException("Parent comment not found");
+            }
+            // depth = 1 제한
+            if(parent.getParentCommentId()!=null){
+                throw new IllegalArgumentException("대댓글에는 답글을 달 수 없습니다.");
+            }
+            // post 정합성
+            if(parent.getPostId()!=postId){
+                throw new IllegalArgumentException("잘못된 요청입니다.");
+            }
+        }
+
         CommentVo commentVo = new CommentVo();
         commentVo.setPostId(postId);
         commentVo.setUserId(loginUserId);
+        commentVo.setParentCommentId(commentDto.getParentCommentId());
         commentVo.setCommentContent(commentDto.getCommentContent());
 
         int inserted = commentDao.insertComment(commentVo);
@@ -32,11 +53,34 @@ public class CommentServiceImpl implements CommentService {
         }
     }
 
-    // [R] - postId
+    // [R] - postId : 게시글 댓글 + 대댓글 조회
     @Override
     @ValidatePostExists(postId = "#postId")
     public List<CommentResponseDto> getCommentByPostId(long postId) {
-        return commentDao.selectCommentsByPostId(postId);
+        List<CommentResponseDto> flat = commentDao.selectCommentsByPostId(postId);
+        Map<Long,CommentResponseDto> map = new HashMap<>();
+        List<CommentResponseDto> replies = new ArrayList<>();
+
+
+        // 부모 댓글 먼저 수집
+        for(CommentResponseDto comment : flat){
+            if(comment.getParentCommentId()==null){
+                map.put(comment.getCommentId(),comment);
+            }else{
+                replies.add(comment);
+            }
+        }
+
+        // 대댓글 연결
+        for(CommentResponseDto reply : replies){
+            CommentResponseDto parent = map.get(reply.getParentCommentId());
+
+            // 부모 없으면 스킵
+            if(parent!=null){
+                parent.getReplies().add(reply);
+            }
+        }
+        return new ArrayList<>(map.values());
     }
 
     // [R] - commentId

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/comment/vo/CommentVo.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/comment/vo/CommentVo.java
@@ -9,6 +9,7 @@ public class CommentVo {
     private long commentId;
     private long postId;
     private long userId;
+    private Long parentCommentId;
     private String commentContent;
     private LocalDateTime commentDate;
     private LocalDateTime commentLastModified;

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
@@ -41,10 +41,6 @@ public class PostController {
                                                                  @RequestParam(defaultValue = "10") int size,
                                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails != null ? userDetails.getUserId() : null;
-        System.out.println(SecurityContextHolder.getContext().getAuthentication());
-
-        System.out.println("userId = " + userId);
-
         PostPageResponseDto response = postService.getAllPosts(page,size,userId);
         return ResponseEntity.ok(response);
     }
@@ -52,10 +48,7 @@ public class PostController {
     // 3. 단건 조회
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponseDto> getPost(@PathVariable long postId, @AuthenticationPrincipal CustomUserDetails user  ) {
-
         Long userId = (user!=null)?user.getUserId():null;
-        System.out.println("userId = " + userId);
-
         PostResponseDto response = postService.getPostById(postId, userId);
         return ResponseEntity.ok(response);
     }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
@@ -162,6 +162,7 @@ public class PostServiceImpl implements PostService {
             throw new IllegalArgumentException("Post not found with id: " + postId);
         }
 
+
         // 2. 작성자 체크
         if(responseDto.getUserId() != loginUserId){
             throw new AccessDeniedException("Access denied 본인의 게시글만 삭제할 수 있습니다.");

--- a/BookSpace/backend/src/main/resources/application.yaml
+++ b/BookSpace/backend/src/main/resources/application.yaml
@@ -22,7 +22,7 @@ mybatis:
   type-aliases-package: com.bookspace.domain
   configuration:
     map-underscore-to-camel-case: true
-    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
+    #log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
 
 aladin:
   ttbkey: ${ALADIN_TTB_KEY}

--- a/BookSpace/backend/src/main/resources/mappers/CommentMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/CommentMapper.xml
@@ -7,37 +7,68 @@
 
     <!-- Create   -->
     <insert id="insertComment" parameterType="commentVo">
-        INSERT INTO comment (post_id, user_id, comment_content)
-        VALUES (#{postId}, #{userId}, #{commentContent})
+        INSERT INTO comment (
+            post_id,
+            user_id,
+            parent_comment_id,
+            comment_content
+        )
+        VALUES (
+                   #{postId},
+                   #{userId},
+                   #{parentCommentId},
+                   #{commentContent}
+               )
     </insert>
 
-    <!--  Read - postId  -->
+    <!--  Read - postId (댓글 + 대댓글) -->
     <select id="selectCommentsByPostId" resultType="commentResponseDto">
-        SELECT *
-        FROM comment
-        WHERE post_id = #{postId}
+        SELECT
+            c.comment_id,
+            c.post_id,
+            c.user_id,
+            u.user_nickname,
+            c.parent_comment_id,
+            c.comment_content,
+            c.comment_date,
+            c.comment_last_modified
+        FROM comment c
+                 JOIN user u ON c.user_id = u.user_id
+        WHERE c.post_id = #{postId}
         ORDER BY comment_date DESC
     </select>
 
     <!-- Read - commentId  -->
     <select id="selectCommentById"  parameterType="long" resultType="commentResponseDto">
         SELECT
-            comment_id,
-            post_id,
-            user_id,
-            comment_content,
-            comment_date,
-            comment_last_modified
-        FROM comment
-        WHERE comment_id = #{commentId}
+            c.comment_id,
+            c.post_id,
+            c.user_id,
+            u.user_nickname,
+            c.parent_comment_id,
+            c.comment_content,
+            c.comment_date,
+            c.comment_last_modified
+        FROM comment c
+                 JOIN user u ON c.user_id = u.user_id
+        WHERE c.comment_id = #{commentId}
     </select>
 
     <!-- Read - userId -->
     <select id="selectCommentsByUserId" resultType="commentResponseDto">
-        SELECT *
-        FROM comment
-        WHERE user_id = #{userId}
-        ORDER BY comment_date DESC
+        SELECT
+            c.comment_id,
+            c.post_id,
+            c.user_id,
+            u.user_nickname,
+            c.parent_comment_id,
+            c.comment_content,
+            c.comment_date,
+            c.comment_last_modified
+        FROM comment c
+                 JOIN user u ON c.user_id = u.user_id
+        WHERE c.user_id = #{userId}
+        ORDER BY c.comment_date DESC
     </select>
 
     <!-- Update - commentId   -->


### PR DESCRIPTION
## PR Summary

- **Type**: feat
- **Scope**: BE(comment)
- **Issue**: #100 / Refs #

## 작업 내용

### Frontend

- N/A

### Backend

- EndPoints
    - `GET /posts/{postId}/comments`
      - 게시글 댓글 / 대댓글 목록 조회 (최신순)
    - `POST /posts/{postId}/comments`
      - 댓글 / 대댓글 작성 (parent_comment_id 포함)

- Contract Changes (req/res)
    - 댓글 생성 요청에 `parentCommentId` 필드 추가
    - 댓글 조회 응답에 `userNickName` 필드 추가
    - 대댓글 여부 판단을 위한 `parentCommentId` 응답 포함

- DB / Mybatis
    - Schema
        - `comment` 테이블에 `parent_comment_id` 컬럼 추가
    - mapper/sql
        - user 테이블 조인을 통한 댓글 작성자 닉네임 조회
        - parent_comment_id 포함 댓글 조회 SQL 수정
        - 댓글 / 대댓글 Create & Read SQL 매핑 추가


## How to Test
1. `POST /posts/{postId}/comments` 호출
   - parentCommentId 없이 요청 → 일반 댓글 생성
   - parentCommentId 포함 요청 → 대댓글 생성
2. `GET /posts/{postId}/comments` 호출

