### PR TITLE
[feat] BookDetailView UI 구현 및 컴포넌트 추가 (#96)

### DIFF
--- a/BookSpace/backend/.idea/data_source_mapping.xml
+++ b/BookSpace/backend/.idea/data_source_mapping.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourcePerFileMappings">
-    <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/eabfd39e-4726-42d0-b9cc-22e95c2863d8/console.sql" value="eabfd39e-4726-42d0-b9cc-22e95c2863d8" />
     <file url="file://$PROJECT_DIR$/src/main/resources/mappers/PostMapper.xml" value="eabfd39e-4726-42d0-b9cc-22e95c2863d8" />
   </component>
 </project>

--- a/BookSpace/frontend/src/components/bookDetail/BookDetailInfo.vue
+++ b/BookSpace/frontend/src/components/bookDetail/BookDetailInfo.vue
@@ -1,0 +1,46 @@
+<template>
+  <section class="space-y-6">
+    <!-- Meta header -->
+    <div class="space-y-2">
+      <!-- 제목 -->
+      <h1 class="text-3xl font-bold leading-tight">
+        {{ book?.title || "제목 없음" }}
+      </h1>
+
+      <!-- 저자 · 출판사 -->
+      <p class="text-base text-muted-foreground">
+        <span>{{ book?.author || "저자 정보 없음" }}</span>
+        <span v-if="book?.publisher" class="ml-2">· {{ book.publisher }}</span>
+      </p>
+
+      <!-- 출간일 -->
+      <p v-if="book?.pubDate" class="text-sm text-muted-foreground">출간일: {{ book.pubDate }}</p>
+    </div>
+
+    <!-- 책 소개 -->
+    <div v-if="book?.description" class="space-y-2">
+      <h2 class="text-xl font-semibold">책 소개</h2>
+      <p class="whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
+        {{ book.description }}
+      </p>
+    </div>
+
+    <!-- 소개 없을 때 -->
+    <div v-else class="rounded-xl border border-input bg-card p-4 text-sm text-muted-foreground">책 소개 정보가 없습니다.</div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  book: {
+    type: Object,
+    required: true, // BookSearchResponseDto 그대로 사용
+  },
+});
+
+const formattedPubDate = computed(() => {
+  return props.book?.pubDate || "";
+});
+</script>

--- a/BookSpace/frontend/src/components/bookDetail/BookSideCard.vue
+++ b/BookSpace/frontend/src/components/bookDetail/BookSideCard.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="space-y-4">
+    <!-- 책표지 -->
+    <div class="overflow-hidden border border-input bg-muted">
+      <img :src="book?.cover || fallbackCover" :alt="book?.title || 'cover'" class="aspect-[2/3] w-full object-cover" loading="lazy" />
+    </div>
+
+    <!-- 찜 버튼 -->
+    <div class="flex">
+      <button
+        type="button"
+        class="flex-1 h-10 inline-flex items-center justify-center gap-2 rounded-md font-extrabold text-base transition-colors"
+        :class="isWished ? 'bg-gray-400 text-primary-foreground cursor-default' : 'bg-primary text-primary-foreground hover:bg-primary/90'"
+        @click="$emit('toggle-wish')"
+      >
+        <span class="text-base leading-none">
+          {{ isWished ? "♥" : "♡" }}
+        </span>
+        {{ isWished ? "찜완료" : "찜하기" }}
+      </button>
+    </div>
+
+    <!-- 평점, 리뷰, 게시글 정보 -->
+    <div class="bg-card rounded-xl border border-input p-4 shadow-sm">
+      <div class="space-y-2 text-sm">
+        <div class="flex items-center justify-between">
+          <span>평점</span>
+          <span class="flex items-center gap-1 font-semibold">
+            <span class="relative -top-[2px] text-yellow-400 text-base leading-none">★</span>
+            <span class="leading-none">{{ averageRatingText }}</span>
+          </span>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <span>리뷰</span>
+          <span class="font-semibold">{{ reviewCount }}개</span>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <span>게시글</span>
+          <span class="font-semibold">{{ postCount }}개</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  book: {
+    type: Object,
+    required: true, // BookSearchResponseDto 그대로
+  },
+  isWished: {
+    type: Boolean,
+    default: false,
+  },
+  averageRating: {
+    type: Number,
+    default: 0,
+  },
+  reviewCount: {
+    type: Number,
+    default: 0,
+  },
+  postCount: {
+    type: Number,
+    default: 0,
+  },
+});
+
+defineEmits(["toggle-wish"]);
+
+/** 표지 없을 때 fallback */
+const fallbackCover =
+  "data:image/svg+xml;charset=UTF-8," +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="600">
+      <rect width="100%" height="100%" fill="#eee"/>
+      <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        fill="#999" font-size="20" font-family="Arial">No Cover</text>
+    </svg>`
+  );
+
+/** 평점 표시용 텍스트 */
+const averageRatingText = computed(() => {
+  const r = Number(props.averageRating || 0);
+  return `${r.toFixed(1)} (${props.reviewCount})`;
+});
+</script>

--- a/BookSpace/frontend/src/components/bookDetail/ReviewPostTabs.vue
+++ b/BookSpace/frontend/src/components/bookDetail/ReviewPostTabs.vue
@@ -1,0 +1,60 @@
+<template>
+  <Tabs2
+    v-model="activeTab"
+    :tabs="tabItems"
+    class="w-full"
+    list-class="bg-muted"
+    panel-class="mt-6"
+    :active-classes="activeClasses"
+    :inactive-classes="inactiveClasses"
+    instance-id="review-post-tabs"
+  >
+    <!-- 리뷰 탭 내용 -->
+    <template #review>
+      <slot name="review" />
+    </template>
+
+    <!-- 토론 탭 내용 -->
+    <template #post>
+      <slot name="post" />
+    </template>
+  </Tabs2>
+</template>
+
+<script setup>
+import { ref, computed, watch } from "vue";
+import Tabs2 from "@/components/ui/Tabs2.vue";
+
+const props = defineProps({
+  // 필요하면 부모에서 v-model로 현재 탭 제어 가능
+  modelValue: { type: String, default: "review" },
+  reviewCount: { type: Number, default: 0 },
+  postCount: { type: Number, default: 0 },
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const activeTab = ref(props.modelValue);
+
+// 버튼에 들어갈 텍스트
+const tabItems = computed(() => [
+  { id: "review", label: `리뷰` },
+  { id: "post", label: `커뮤니티` },
+]);
+
+// 선택된 탭 스타일
+const activeClasses = "bg-background text-foreground shadow-sm font-semibold";
+const inactiveClasses = "text-foreground";
+
+// v-model 동기화
+watch(
+  () => props.modelValue,
+  (v) => {
+    if (v && v !== activeTab.value) activeTab.value = v;
+  }
+);
+
+watch(activeTab, (v) => {
+  emit("update:modelValue", v);
+});
+</script>

--- a/BookSpace/frontend/src/components/postInBookDetail/PostCreateModal.vue
+++ b/BookSpace/frontend/src/components/postInBookDetail/PostCreateModal.vue
@@ -1,0 +1,78 @@
+<template>
+  <Teleport to="body">
+    <!-- overlay -->
+    <div class="fixed inset-0 z-50 flex items-center justify-center" role="dialog" aria-modal="true" @keydown.esc="close" tabindex="-1" ref="root">
+      <!-- dim -->
+      <div class="absolute inset-0 bg-black/40" @click="close"></div>
+
+      <!-- panel -->
+      <div class="relative z-10 w-[560px] max-w-[92vw] rounded-xl bg-background border shadow-xl" @click.stop>
+        <!-- header -->
+        <div class="flex items-center justify-between px-6 py-4">
+          <h3 class="text-lg font-semibold text-foreground">토론 게시글 작성</h3>
+
+          <button type="button" class="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-muted transition" aria-label="닫기" @click="close">✕</button>
+        </div>
+
+        <!-- body -->
+        <div class="px-6 pb-6 space-y-4">
+          <div class="space-y-2">
+            <label class="text-sm font-medium text-foreground">제목</label>
+            <input
+              v-model.trim="title"
+              type="text"
+              placeholder="게시글 제목을 입력하세요"
+              class="w-full h-10 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring"
+              maxlength="60"
+            />
+          </div>
+
+          <div class="space-y-2">
+            <label class="text-sm font-medium text-foreground">내용</label>
+            <textarea
+              v-model.trim="content"
+              placeholder="내용을 입력하세요"
+              class="w-full min-h-[180px] resize-none rounded-md border border-input bg-background p-3 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring"
+              maxlength="2000"
+            />
+          </div>
+
+          <button
+            type="button"
+            class="w-full h-11 rounded-md font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50 bg-muted-foreground/60"
+            :class="canSubmit ? 'bg-primary hover:bg-primary/90' : ''"
+            :disabled="!canSubmit"
+            @click="submit"
+          >
+            게시글 등록
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed, nextTick, onMounted, ref } from "vue";
+
+const emit = defineEmits(["close", "submit"]);
+
+const title = ref("");
+const content = ref("");
+
+const canSubmit = computed(() => title.value.length > 0 && content.value.length > 0);
+
+const close = () => emit("close");
+
+const submit = () => {
+  if (!canSubmit.value) return;
+  emit("submit", { title: title.value, content: content.value });
+};
+
+// 모달 뜰 때 키보드 이벤트(ESC) 잘 먹게 포커스
+const root = ref(null);
+onMounted(async () => {
+  await nextTick();
+  root.value?.focus?.();
+});
+</script>

--- a/BookSpace/frontend/src/components/postInBookDetail/PostSection.vue
+++ b/BookSpace/frontend/src/components/postInBookDetail/PostSection.vue
@@ -1,0 +1,40 @@
+<template>
+  <section class="space-y-6">
+    <!-- 헤더 -->
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-foreground">토론 게시글</h2>
+
+      <!-- 스샷 느낌: + 아이콘 + 게시글 작성 -->
+      <Button class="h-9 px-4 text-white font-extrabold inline-flex items-center gap-2" @click="openCreateModal">
+        <PlusIcon class="w-4 h-4" />
+        게시글 작성
+      </Button>
+    </div>
+
+    <!-- 리스트 -->
+    <PostList />
+
+    <!-- 작성 모달 -->
+    <PostCreateModal v-if="isModalOpen" @close="isModalOpen = false" @created="handleCreated" />
+  </section>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import Button from "@/components/ui/Button.vue";
+import { PlusIcon } from "lucide-vue-next";
+
+import PostCreateModal from "./PostCreateModal.vue";
+
+const isModalOpen = ref(false);
+
+const openCreateModal = () => {
+  isCreateOpen.value = true;
+};
+
+// (선택) 작성 완료 후 모달 닫기 + 리스트 갱신 트리거 연결용
+const handleCreated = () => {
+  isCreateOpen.value = false;
+  // 여기서 refetch() 하거나, 상위에 emit해서 다시 불러오게 연결 가능
+};
+</script>

--- a/BookSpace/frontend/src/components/review/ReviewCard.vue
+++ b/BookSpace/frontend/src/components/review/ReviewCard.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="w-full p-5 border border-border rounded-xl bg-card shadow-sm">
+    <!-- 상단: 닉네임, 작성일자, 평점 -->
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <p class="font-semibold text-foreground">
+          {{ review.nickname }}
+        </p>
+        <p class="text-sm text-muted-foreground">
+          {{ formattedDate }}
+        </p>
+      </div>
+
+      <div class="flex items-center gap-1">
+        <span class="relative -top-[2px] text-yellow-400 leading-none">★</span>
+        <span class="font-bold text-foreground">
+          {{ review.reviewRating }}
+        </span>
+      </div>
+    </div>
+
+    <!-- 리뷰 내용-->
+    <p class="mt-4 text-sm text-foreground whitespace-pre-line">
+      {{ review.reviewContent }}
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  review: {
+    type: Object,
+    required: true,
+  },
+});
+
+const formattedDate = computed(() => {
+  if (!props.review.reviewDate) return "";
+  const date = new Date(props.review.reviewDate);
+  return date.toLocaleDateString("ko-KR");
+});
+</script>

--- a/BookSpace/frontend/src/components/review/ReviewCreate.vue
+++ b/BookSpace/frontend/src/components/review/ReviewCreate.vue
@@ -1,0 +1,138 @@
+<!-- 이미 작성된 리뷰 목록을 보이도록 하기 위해 리뷰를 작성하지 않는 경우 간단한 화면이 보임
+ 리뷰를 작성하기 위해 해당 card를 클릭하면 리뷰 등록 화면이 펼쳐지는 구조 -->
+<template>
+  <div class="rounded-xl border border-input bg-card p-6 shadow-sm">
+    <!-- 평점-->
+    <div>
+      <p class="text-base font-normal mb-2">평점</p>
+
+      <!-- 접힌 상태에서도 별점 선택 가능 -->
+      <div>
+        <StarRating v-model="rating" :step="0.5" :showValue="true" />
+      </div>
+    </div>
+
+    <!-- 내용 -->
+    <div class="mt-6">
+      <p class="text-base font-normal">내용(선택사항)</p>
+
+      <!-- 접힌 상태 textarea -->
+      <div v-if="!isExpanded" class="mt-3 flex items-start gap-3">
+        <textarea
+          v-model="content"
+          :maxlength="maxLength"
+          rows="1"
+          class="flex-1 h-10 overflow-hidden rounded-md border border-input bg-background px-4 py-2 text-sm outline-none placeholder:text-muted-foreground resize-none transition-all duration-200 ease-out"
+          placeholder="이 책에 대한 생각을 자유롭게 적어주세요 (최대 300자)"
+          @click="expand"
+        ></textarea>
+
+        <!-- 접힌 상태 버튼
+             - 기본 회색
+             - 별점 선택 시 primary
+             - 클릭 시 바로 등록(별점만 등록) -->
+        <button
+          type="button"
+          class="h-10 shrink-0 rounded-md px-5 text-sm font-semibold text-white disabled:opacity-60"
+          :class="canSubmit ? 'bg-primary hover:bg-primary/90' : 'bg-gray-400'"
+          :disabled="props.isSubmitting"
+          @click="onSubmitCollapsed"
+        >
+          등록
+        </button>
+      </div>
+
+      <!-- 펼친 상태 -->
+      <div v-else>
+        <textarea
+          v-model="content"
+          :maxlength="maxLength"
+          class="mt-3 w-full h-[160px] rounded-md border border-input bg-background p-4 text-sm outline-none focus-visible:ring-[3px] focus-visible:border-primary focus-visible:ring-ring/50 placeholder:text-muted-foreground resize-none"
+          placeholder="이 책에 대한 생각을 자유롭게 적어주세요 (최대 300자)"
+        ></textarea>
+
+        <div class="mt-2 flex justify-between">
+          <span class="text-sm text-muted-foreground">{{ content.length }}/{{ maxLength }}</span>
+        </div>
+
+        <button
+          type="button"
+          class="mt-6 h-10 w-full rounded-md bg-gray-400 text-base font-semibold text-white disabled:opacity-60"
+          :class="canSubmit ? 'bg-primary hover:bg-primary/90' : ''"
+          :disabled="props.isSubmitting"
+          @click="onSubmitExpanded"
+        >
+          {{ props.isSubmitting ? "등록 중..." : "등록하기" }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, ref } from "vue";
+import StarRating from "../ui/StarRating.vue";
+
+const props = defineProps({
+  maxLength: { type: Number, default: 300 },
+  isSubmitting: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["submit"]);
+
+const rating = ref(0);
+const content = ref("");
+const isExpanded = ref(false);
+
+const canSubmit = computed(() => rating.value > 0);
+
+const expand = async () => {
+  if (isExpanded.value) return;
+  isExpanded.value = true;
+  await nextTick();
+};
+
+// 리뷰 작성 API(emit) 호출 로직은 하나로 통일
+function submitReview(payloadContent) {
+  if (props.isSubmitting) return;
+
+  // 별점 선택 안했을시
+  if (rating.value === 0) {
+    alert("별점을 선택해주세요");
+    return;
+  }
+
+  emit("submit", {
+    rating: rating.value,
+    content: payloadContent, // null 또는 string
+  });
+
+  // 공통 초기화
+  content.value = "";
+  rating.value = 0;
+}
+
+// 접힌 상태: 별점만 등록
+function onSubmitCollapsed() {
+  submitReview(null);
+}
+
+// 펼친 상태: 별점 + 내용 등록 후 다시 접힘
+function onSubmitExpanded() {
+  submitReview(content.value.trim() || null);
+
+  // 펼친 상태에서 등록 후 다시 접힘
+  isExpanded.value = false;
+}
+</script>
+
+<style scoped>
+:deep(.p-rating-icon) {
+  font-size: 1.875rem; /* 30px */
+  color: #e5e7eb; /* gray-200 */
+}
+
+:deep(.p-rating-item.p-rating-item-active .p-rating-icon) {
+  color: #facc15; /* yellow-400 */
+}
+</style>

--- a/BookSpace/frontend/src/components/review/ReviewList.vue
+++ b/BookSpace/frontend/src/components/review/ReviewList.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="space-y-4">
+    <!-- 리뷰 없음 -->
+    <div v-if="!reviews?.length" class="rounded-xl border border-dashed border-border bg-card p-10 text-center text-sm text-muted-foreground">첫 번째 리뷰를 작성해보세요!</div>
+
+    <!-- 리뷰 목록 -->
+    <ReviewCard v-else v-for="review in reviews" :key="review.reviewId ?? review.id" :review="review" />
+  </div>
+</template>
+
+<script setup>
+import ReviewCard from "./ReviewCard.vue";
+
+defineProps({
+  reviews: {
+    type: Array,
+    default: () => [],
+  },
+});
+</script>

--- a/BookSpace/frontend/src/components/review/ReviewSection.vue
+++ b/BookSpace/frontend/src/components/review/ReviewSection.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="space-y-6">
+    <ReviewCreate></ReviewCreate>
+    <ReviewList :reviews="reviews"></ReviewList>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import ReviewCreate from "./ReviewCreate.vue";
+import ReviewList from "./ReviewList.vue";
+
+// defineProps({
+//   reviews: { type: Array, default: () => [] },
+// });
+
+const reviews = ref([
+  {
+    reviewId: 1,
+    nickname: "독서왕",
+    reviewDate: "2025-12-17T10:23:11",
+    reviewRating: 4.5,
+    reviewContent: "생각보다 훨씬 몰입해서 읽었어요.\n삼국지를 처음 접하는 사람에게 정말 좋은 입문서라고 느꼈습니다.",
+  },
+  {
+    reviewId: 2,
+    nickname: "책벌레",
+    reviewDate: "2025-12-15T21:10:03",
+    reviewRating: 4.0,
+    reviewContent: "내용 정리가 잘 되어 있어서 읽기 편했어요.\n다만 이미 삼국지를 알고 있다면 조금 단순하게 느껴질 수도 있을 것 같아요.",
+  },
+  {
+    reviewId: 3,
+    nickname: "초보독자",
+    reviewDate: "2025-12-14T08:42:55",
+    reviewRating: 5.0,
+    reviewContent: "삼국지 이름만 알고 있었는데 이 책 덕분에 전체 흐름을 이해할 수 있었어요!\n강의 듣는 느낌이라 재밌었습니다.",
+  },
+]);
+</script>
+
+<style scoped></style>

--- a/BookSpace/frontend/src/components/ui/StarRating.vue
+++ b/BookSpace/frontend/src/components/ui/StarRating.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="flex items-center gap-1">
+    <button v-for="i in max" :key="i" type="button" class="relative transition-transform hover:scale-110" @click="(e) => onClickStar(e, i)">
+      <!-- 회색 별 -->
+      <Star class="h-6 w-6 text-gray-300" :stroke-width="1.5" />
+
+      <!-- 노란 별 (덮기) -->
+      <div class="absolute left-0 top-0 overflow-hidden" :style="{ width: fillWidth(i) }">
+        <Star class="h-6 w-6 text-yellow-400" :stroke-width="1.5" fill="currentColor" />
+      </div>
+    </button>
+
+    <span class="ml-2 text-lg text-muted-foreground font-semibold">
+      {{ displayValue.toFixed(1) }}
+    </span>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { Star } from "lucide-vue-next";
+
+const props = defineProps({
+  modelValue: { type: Number, default: 0 },
+  max: { type: Number, default: 5 },
+  step: { type: Number, default: 0.5 }, // 0.5 or 1
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const displayValue = computed(() => props.modelValue);
+
+function onClickStar(e, index) {
+  if (props.step !== 0.5) {
+    emit("update:modelValue", index);
+    return;
+  }
+
+  const rect = e.currentTarget.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const half = x < rect.width / 2 ? 0.5 : 1;
+
+  emit("update:modelValue", index - 1 + half);
+}
+
+function fillWidth(index) {
+  const v = displayValue.value;
+  const start = index - 1;
+
+  if (v <= start) return "0%";
+  if (v >= index) return "100%";
+
+  return `${(v - start) * 100}%`; // 50%
+}
+</script>

--- a/BookSpace/frontend/src/components/ui/Tabs2.vue
+++ b/BookSpace/frontend/src/components/ui/Tabs2.vue
@@ -1,0 +1,142 @@
+<template>
+  <!-- Tabs 컨테이너: Flowbite Tabs의 parent element 역할 -->
+  <div ref="rootEl" :class="wrapperClasses" data-slot="tabs">
+    <!-- Tab list -->
+    <div :class="listClasses" role="tablist" data-slot="tabs-list">
+      <button
+        v-for="tab in tabs"
+        :key="tab.id"
+        :id="triggerId(String(tab.id))"
+        type="button"
+        role="tab"
+        :disabled="!!tab.disabled"
+        :aria-selected="activeId === String(tab.id)"
+        :aria-controls="panelId(String(tab.id))"
+        :class="baseClasses"
+        @click="onClickTab(tab)"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <!-- Panels -->
+    <div>
+      <div
+        v-for="tab in tabs"
+        :key="`${tab.id}-panel`"
+        :id="panelId(String(tab.id))"
+        role="tabpanel"
+        :aria-labelledby="triggerId(String(tab.id))"
+        :class="[panelClass, activeId === String(tab.id) ? '' : 'hidden'].join(' ')"
+      >
+        <!-- 각 탭 컨텐츠는 named slot으로 -->
+        <slot :name="String(tab.id)" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { Tabs } from "flowbite";
+
+const props = defineProps({
+  modelValue: { type: [String, Number], default: "" },
+  tabs: { type: Array, required: true },
+  class: { type: String, default: "" },
+  listClass: { type: String, default: "" },
+  panelClass: { type: String, default: "" },
+  activeClasses: { type: String, default: "" },
+  inactiveClasses: { type: String, default: "" },
+  instanceId: { type: String, default: "tabs-instance" },
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const rootEl = ref(null);
+let tabsInstance = null;
+
+// 버튼 (안쪽 도형) 기본 스타일
+const baseClasses =
+  "flex-1 inline-flex items-center justify-center " +
+  "h-6 rounded-md text-sm font-md" +
+  "transition-[background,color,box-shadow] outline-none " +
+  "focus-visible:ring-[3px] focus-visible:ring-ring/50 " +
+  "disabled:pointer-events-none disabled:opacity-50";
+
+// 전체 너비 + 바깥 배경
+const wrapperClasses = computed(() => ["w-full flex flex-col gap-2", props.class].join(" "));
+
+// 회색 배경이 깔린 트랙
+const listClasses = computed(() => ["flex w-full items-center rounded-md bg-muted px-[3px] py-[4px]", props.listClass].join(" "));
+
+// 현재 active id
+const activeId = computed(() => {
+  const v = String(props.modelValue ?? "");
+  if (v) return v;
+  return props.tabs?.[0]?.id ? String(props.tabs[0].id) : "";
+});
+
+function triggerId(tabId) {
+  return `${props.instanceId}-${tabId}-tab`;
+}
+function panelId(tabId) {
+  return `${props.instanceId}-${tabId}-panel`;
+}
+
+async function initFlowbiteTabs() {
+  await nextTick();
+  const el = rootEl.value;
+  if (!el) return;
+
+  const items = props.tabs.map((t) => {
+    const id = String(t.id);
+    return {
+      id,
+      triggerEl: el.querySelector(`#${triggerId(id)}`),
+      targetEl: el.querySelector(`#${panelId(id)}`),
+    };
+  });
+
+  // 기존 인스턴스가 있으면 교체
+  tabsInstance = new Tabs(
+    el,
+    items,
+    {
+      defaultTabId: activeId.value,
+      activeClasses: props.activeClasses,
+      inactiveClasses: props.inactiveClasses,
+    },
+    { id: props.instanceId, override: true } // 문서에 있는 instanceOptions 패턴 :contentReference[oaicite:3]{index=3}
+  );
+
+  // 초기 v-model과 동기화
+  tabsInstance.show(activeId.value);
+}
+
+onMounted(initFlowbiteTabs);
+
+// 탭 목록이 바뀌거나(조건부 렌더링/라우팅) modelValue가 바뀌면 동기화
+watch(
+  () => props.tabs.map((t) => `${t.id}:${!!t.disabled}`).join("|"),
+  () => initFlowbiteTabs()
+);
+
+watch(
+  () => props.modelValue,
+  (v) => {
+    const id = String(v ?? "");
+    if (tabsInstance && id) tabsInstance.show(id); // :contentReference[oaicite:5]{index=5}
+  }
+);
+
+onBeforeUnmount(() => {
+  tabsInstance = null;
+});
+
+// 클릭 시 v-model 업데이트 (Flowbite도 같은 클릭으로 동작)
+function onClickTab(tab) {
+  if (tab.disabled) return;
+  emit("update:modelValue", tab.id);
+}
+</script>

--- a/BookSpace/frontend/src/views/BookDetailView.vue
+++ b/BookSpace/frontend/src/views/BookDetailView.vue
@@ -1,13 +1,65 @@
 <template>
-    <div>
-        <h2>책 상세화면</h2>
+  <main class="mx-auto max-w-6xl px-4 py-6">
+    <div class="grid gap-6 md:grid-cols-[240px_1fr]">
+      <!-- LEFT -->
+      <aside class="lg:sticky lg:top-6 h-fit">
+        <BookSideCard :book="book" :is-wished="isWished" :average-rating="averageRating" :review-count="reviewCount" :post-count="postCount" @toggle-wish="toggleWish" />
+      </aside>
+
+      <!-- RIGHT -->
+      <section class="space-y-10">
+        <!-- 책 상세정보 -->
+        <BookDetailInfo :book="book" />
+
+        <!-- 리뷰 / 게시글 탭 -->
+        <ReviewPostTabs v-model="activeTab" :review-count="reviewCount" :post-count="postCount">
+          <!-- ReviewSection -->
+          <template #review>
+            <ReviewSection />
+          </template>
+
+          <!-- PostSection -->
+          <template #post>
+            <PostSection />
+          </template>
+        </ReviewPostTabs>
+      </section>
     </div>
+  </main>
 </template>
 
 <script setup>
+import { ref } from "vue";
+import BookDetailInfo from "../components/bookDetail/BookDetailInfo.vue";
+import BookSideCard from "@/components/bookDetail/BookSideCard.vue";
+import ReviewPostTabs from "../components/bookDetail/ReviewPostTabs.vue";
 
+import ReviewSection from "@/components/review/ReviewSection.vue";
+import PostSection from "@/components/postInBookDetail/PostSection.vue";
+
+const activeTab = ref("review");
+
+/**
+ * 화면 확인용 더미 데이터
+ * (BookSearchResponseDto 형태 그대로)
+ */
+const book = ref({
+  title: "최소한의 삼국지 - 최태성의 삼국지 고전 특강",
+  author: "최태성 (지은이), 이성원 (감수)",
+  publisher: "프런트페이지",
+  pubDate: "2025-11-18",
+  isbn13: "9791193401583",
+  cover: "https://image.aladin.co.kr/product/37773/21/cover200/k002033562_2.jpg",
+  description: "인생의 필독서로 손꼽히는 ‘삼국지’를 한 권으로 정리한 입문서입니다.",
+});
+
+// UI용 더미 상태
+const isWished = ref(false);
+const averageRating = ref(4.8);
+const reviewCount = ref(12);
+const postCount = ref(3);
+
+function toggleWish() {
+  isWished.value = !isWished.value;
+}
 </script>
-
-<style scoped>
-
-</style>


### PR DESCRIPTION
## UI 구성 작업

### BookDetailView
- 도서 상세 조회 화면 전체 레이아웃 구성
- 좌측 사이드 영역 + 우측 콘텐츠 영역 구조 분리
- 리뷰 / 게시글을 탭으로 전환하여 확인 가능하도록 설계

```
BookDetailView
 ├─ BookSideCard
 ├─ BookDetailInfo
 └─ ReviewPostTabs
     ├─ ReviewSection
     │   ├─ ReviewCreate
     │   └─ ReviewList
     │       └─ ReviewCard
     └─ PostSection
         ├─ PostList
         │   └─ PostCard
         └─ PostCreateModal
```
<br>

## 공용 UI 컴포넌트 추가 (components/ui)
- **Tabs2**
  - 리뷰 / 게시글 탭 전환을 위한 공용 탭 컴포넌트
- **StarRating**
  - 리뷰 평점 표시 및 입력에 사용되는 별점 컴포넌트

<br>

## 도서 상세 관련 컴포넌트 (components/bookDetail)
- **BookDetailInfo**
  - 도서 상세 정보(제목, 저자, 출판사 등) 표시
- **BookSideCard**
  - 도서 상세 화면 좌측 영역 UI
  - 책 표지, 찜하기 버튼
  - 평균 평점, 리뷰 수, 게시글 수 표시
- **ReviewPostTabs**
  - 리뷰 / 게시글을 탭으로 전환하여 확인 가능하도록 구성

<br>

## 도서 상세 내 게시글 영역 (components/postInBookDetail)
- **PostCreateModal**
  - 도서 상세 조회 화면 내 게시글 작성용 모달
- **PostSection**
  - 게시글 탭 선택 시 노출되는 영역
  - 기존 `Community > PostCard` 컴포넌트를 재사용하여 구성 예정

<br>

## 리뷰 관련 컴포넌트 (components/review)
- **ReviewCard**
  - 개별 리뷰 UI 카드
- **ReviewCreate**
  - 별점 + 텍스트 기반 리뷰 작성 영역
- **ReviewList**
  - 리뷰 목록 렌더링
- **ReviewSection**
  - 리뷰 탭 선택 시 노출되는 전체 리뷰 영역

