### PR TITLE
[feat] BE 도서 상세조회 API 구현 및 리뷰/게시글 메타 정보 연동 (#104)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/controller/BookController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/controller/BookController.java
@@ -1,5 +1,6 @@
 package com.bookspace.domain.book.controller;
 
+import com.bookspace.domain.book.dto.BookDetailResponseDto;
 import com.bookspace.domain.book.dto.BookSearchResponseDto;
 import com.bookspace.domain.book.service.BookService;
 import lombok.RequiredArgsConstructor;
@@ -78,5 +79,19 @@ public class BookController {
     ) {
         // type: "new" | "bestseller"
         return bookService.getDefaultBooksFromAladin(type);
+    }
+
+
+    /**
+     * 5. 도서 상세조회 (ISBN 기반)
+     * - DB에 있으면 DB 정보로 반환
+     * - DB에 없으면 알라딘 API로 조회하여 반환 (저장 X)
+     * - DB에 없는 책은 메타 정보 기본값(0/false) 반환
+     *
+     * GET /books/detail/{isbn}
+     */
+    @GetMapping("/detail/{isbn}")
+    public BookDetailResponseDto getBookDetail(@PathVariable String isbn) {
+        return bookService.getBookDetail(isbn);
     }
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/converter/BookConverter.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/converter/BookConverter.java
@@ -1,6 +1,7 @@
 package com.bookspace.domain.book.converter;
 
 import com.bookspace.domain.book.dto.AladinItemResponseDto;
+import com.bookspace.domain.book.dto.BookDetailResponseDto;
 import com.bookspace.domain.book.dto.BookSearchResponseDto;
 import com.bookspace.domain.book.vo.BookVo;
 
@@ -64,6 +65,42 @@ public final class BookConverter {
         dto.setCover(item.getCover());
         dto.setCategoryName(item.getCategoryName());
         dto.setDescription(item.getDescription());
+        return dto;
+    }
+
+
+    // DB에서 조회 -> Detail DTO
+    public static BookDetailResponseDto toDetailResponseFromBookVo(BookVo vo) {
+        if (vo == null) return null;
+
+        BookDetailResponseDto dto = new BookDetailResponseDto();
+        dto.setBookId(vo.getBookId());
+        dto.setIsbn(vo.getBookIsbn());
+        dto.setTitle(vo.getBookTitle());
+        dto.setAuthor(vo.getBookAuthor());
+        dto.setPublisher(vo.getBookPublisher());
+        dto.setPubDate(vo.getBookPublicationDate());
+        dto.setCover(vo.getBookImageUrl());
+        dto.setDescription(vo.getBookDescription());
+
+        return dto;
+    }
+
+    // 알라딘 API 조회 -> Detail DTO
+    public static BookDetailResponseDto toDetailResponseFromAladinItem(
+            AladinItemResponseDto item
+    ) {
+        if (item == null) return null;
+
+        BookDetailResponseDto dto = new BookDetailResponseDto();
+        dto.setIsbn(item.getIsbn13());   // 또는 item.getIsbn() → 실제 필드명만 확인
+        dto.setTitle(item.getTitle());
+        dto.setAuthor(item.getAuthor());
+        dto.setPublisher(item.getPublisher());
+        dto.setPubDate(item.getPubDate());
+        dto.setCover(item.getCover());
+        dto.setDescription(item.getDescription());
+
         return dto;
     }
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/dto/BookDetailResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/dto/BookDetailResponseDto.java
@@ -1,0 +1,32 @@
+package com.bookspace.domain.book.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BookDetailResponseDto {
+
+    // DB / 알라딘 API 상관없이 도서의 상세정보를 반환할 때 사용
+    // 프론트의 BookDetailView에 전달
+
+    // URL 식별자
+    private String isbn;
+
+    // DB에 저장된 경우에만 존재 (없으면 null)
+    private Long bookId;
+
+    // 책 기본 정보 (DB / 알라딘API)
+    private String title;
+    private String author;
+    private String publisher;
+    private String pubDate;
+    private String cover;
+    private String description;
+
+    // 서비스 메타 정보
+    private Double averageRating;  // DB 없으면 0.0
+    private Integer reviewCount;   // DB 없으면 0
+    private Integer postCount;     // DB 없으면 0
+    private Boolean isWished;      // DB에 없거나 비로그인 등은 false
+}

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookService.java
@@ -1,6 +1,7 @@
 package com.bookspace.domain.book.service;
 
 import com.bookspace.domain.book.dto.AladinItemResponseDto;
+import com.bookspace.domain.book.dto.BookDetailResponseDto;
 import com.bookspace.domain.book.dto.BookSearchResponseDto;
 import com.bookspace.domain.book.vo.BookVo;
 
@@ -19,4 +20,7 @@ public interface BookService {
 
     // 검색어 없이 알라딘 API 호출하여 기본 목록 조회
     List<BookSearchResponseDto> getDefaultBooksFromAladin(String type);
+
+    // ISBN 기반 도서 상세 정보 조회
+    BookDetailResponseDto getBookDetail(String isbn);
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
@@ -3,16 +3,18 @@ package com.bookspace.domain.book.service;
 import com.bookspace.domain.book.dao.BookDao;
 import com.bookspace.domain.book.dto.AladinItemResponseDto;
 import com.bookspace.domain.book.dto.AladinListResponseDto;
+import com.bookspace.domain.book.dto.BookDetailResponseDto;
 import com.bookspace.domain.book.dto.BookSearchResponseDto;
 import com.bookspace.domain.book.external.AladinClient;
 import com.bookspace.domain.book.vo.BookVo;
+import com.bookspace.domain.post.dao.PostDao;
+import com.bookspace.domain.review.dao.ReviewDao;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.bookspace.domain.book.converter.BookConverter;
 
 
-import java.awt.print.Book;
 import java.util.List;
 
 @Service
@@ -21,6 +23,9 @@ public class BookServiceImpl implements BookService {
 
     private final BookDao bookDao;
     private final AladinClient aladinClient;
+    // 순환의존성 문제로 DAO를 직접 주입
+    private final ReviewDao reviewDao;
+    private final PostDao postDao;
 
 
     // [검색] DB 검색 시 없으면 알라딘 API 호출
@@ -148,4 +153,67 @@ public class BookServiceImpl implements BookService {
                 .map(BookConverter::toSearchResponseFromAladinItem)
                 .toList();
     }
+
+    /**
+     * [상세조회용 - 저장 X] ISBN으로 알라딘 API 단건 조회
+     * - DB 저장 없이 조회 결과(단건 item)만 반환
+     * - 내부적으로 ItemSearch + QueryType=ISBN + MaxResults=1 사용
+     */
+    private AladinItemResponseDto fetchBookByIsbnFromAladinNoSave(String isbn) {
+        AladinListResponseDto apiResponse = aladinClient.searchBooks(isbn, "isbn", 1);
+
+        if (apiResponse == null || apiResponse.getItems() == null || apiResponse.getItems().isEmpty()) {
+            throw new IllegalArgumentException("Book Not Found for ISBN: " + isbn);
+        }
+
+        return apiResponse.getItems().get(0);
+    }
+
+
+    // 도서 상세조회 시
+    // DB에 있는 책 -> DB에서 조회
+    // DB에 없는 책 -> 알라딘 API 호출 (저장 X, 단순 조회)
+    @Override
+    public BookDetailResponseDto getBookDetail(String isbn) {
+        if (isbn == null || isbn.isBlank()) {
+            throw new IllegalArgumentException("isbn is null or empty");
+        }
+
+        // 1) DB 우선 조회
+        BookVo existing = bookDao.findBookByIsbn(isbn);
+
+        if (existing != null) {
+            BookDetailResponseDto dto = BookConverter.toDetailResponseFromBookVo(existing);
+
+            Long bookId = existing.getBookId();
+
+            // 메타값
+            Double avgRating = reviewDao.selectAverageRating(bookId);
+            Integer reviewCnt = reviewDao.countReviews(bookId);
+            Integer postCnt = postDao.countPostsByBookId(bookId);
+
+            // 메타 기본값 (다음 단계에서 review/post/wish 연결)
+            dto.setAverageRating(avgRating == null ? 0.0 : avgRating);
+            dto.setReviewCount(reviewCnt == null ? 0 : reviewCnt);
+            dto.setPostCount(postCnt == null ? 0 : postCnt);
+            dto.setIsWished(false);
+
+            return dto;
+        }
+
+        // 2) DB에 없으면 알라딘 호출(저장 X)
+        AladinItemResponseDto item = fetchBookByIsbnFromAladinNoSave(isbn);
+        BookDetailResponseDto dto = BookConverter.toDetailResponseFromAladinItem(item);
+
+        // DB에 없는 책이면 메타 기본값
+        dto.setAverageRating(0.0);
+        dto.setReviewCount(0);
+        dto.setPostCount(0);
+        dto.setIsWished(false);
+
+        return dto;
+    }
+
+
+
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/dao/PostDao.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/dao/PostDao.java
@@ -49,4 +49,6 @@ public interface PostDao {
     // 11. 유저가 좋아요를 누른 모든 게시글 조회
     List<PostVo> selectLikedPostsByUserId(@Param("userId") Long userId);
 
+    // 12. 특정 책에 대한 게시글 개수
+    Integer countPostsByBookId(@Param("bookId") long bookId);
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostService.java
@@ -38,4 +38,6 @@ public interface PostService {
     // 유저가 좋아하는 게시글 전체조회
     List<PostResponseDto> getLikedPostsByUserId(Long userId);
 
+    // 특정 책에 대한 게시글 개수 조회
+    Integer getPostCountByBookId(long bookId);
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
@@ -220,6 +220,10 @@ public class PostServiceImpl implements PostService {
                 .toList();
     }
 
+    @Override
+    public Integer getPostCountByBookId(long bookId) {
+        return postDao.countPostsByBookId(bookId);
+    }
 
 
 

--- a/BookSpace/backend/src/main/resources/mappers/PostMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/PostMapper.xml
@@ -267,4 +267,13 @@
         ORDER BY p.post_date DESC
 
     </select>
+
+    <!-- 12. 특정 책에 대한 게시글 개수 (active 유저 기준) -->
+    <select id="countPostsByBookId" resultType="int">
+        SELECT COUNT(*)
+        FROM post p
+                 JOIN user u ON p.user_id = u.user_id
+        WHERE p.book_id = #{bookId}
+          AND u.user_status = 'active'
+    </select>
 </mapper>

--- a/BookSpace/backend/src/main/resources/mappers/ReviewMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/ReviewMapper.xml
@@ -108,8 +108,9 @@
 
 
     <!-- 특정 책에 대한 평균 평점 조회 -->
+        <!-- review가 0개면 AVG가 null 나올 수 있기 때문에 IFNULL로 처리 -->
     <select id="selectAverageRating" resultType="double">
-        SELECT AVG(review_rating)
+        SELECT IFNULL(AVG(review_rating),0)
         FROM review r
         JOIN user u ON r.user_id = u.user_id
         WHERE r.book_id = #{bookId}
@@ -121,7 +122,7 @@
         SELECT COUNT(*)
         FROM review r
         JOIN user u ON r.user_id = u.user_id
-        WHERE book_id = #{bookId}
+        WHERE r.book_id = #{bookId}
           AND u.user_status = 'active'
     </select>
 


### PR DESCRIPTION
## 📝 Description

도서 상세조회 화면(BookDetailView)에서 사용할 **ISBN13 기반 상세조회 API**를 구현

DB에 책이 존재하는 경우 DB에서 데이터를 가져오고, DB에 존재하지 않는 책에 대해서는 알라딘 API를 호출하여 도서 정보를 조회하도록 구현

DB에 저장된 책에 대해서는 리뷰 및 게시글 메타 정보(개수/평균 평점)를 함께 반환하여  
프론트엔드에서 상세 화면을 구성하는 데 필요한 데이터를 한 번에 제공하도록 개선


## 주요 작업 내용

### 1. 도서 상세조회 API 신규 구현
- `GET /books/detail/{isbn}`
- ISBN13 기반 도서 상세조회 API 추가
- **DB 우선 조회 → DB에 없을 경우 알라딘 API 호출(fallback, 저장 X)** 구조로 구현
- DB / 알라딘 API 응답을 동일한 DTO로 통합하여 반환


### 2. BookDetailResponseDto 추가
- 도서 상세조회 전용 DTO 신규 생성
- DB / 알라딘 API 공통 필드 통합
- 상세 화면에 필요한 메타 정보 포함
  - `averageRating`
  - `reviewCount`
  - `postCount`
  - `isWished` (현재 기본값 false)


### 3. BookConverter 확장
- `BookVo → BookDetailResponseDto` 변환 로직 추가
- `AladinItemResponseDto → BookDetailResponseDto` 변환 로직 추가
- 상세조회 응답 포맷 일관성 확보


### 4. 리뷰 메타 정보 집계 로직 구현
- 특정 책(bookId)에 대한 평균 평점 및 리뷰 개수 조회
- **active 상태의 유저가 작성한 리뷰만 집계**
- 상세조회 성격에 맞게 DAO 직접 호출 방식으로 집계 처리


### 5. 게시글 메타 정보 집계 로직 추가
- 특정 책(bookId)에 대한 게시글 개수(`postCount`) 집계 기능 구현
- active 유저 기준으로 게시글 개수 조회
- 상세조회 API 응답에 연동


### 6. 서비스 순환 의존성(Circular Dependency) 문제 해결
- BookService ↔ ReviewService / PostService 간 순환 참조 제거
- 조회용 집계 로직을 DAO 직접 호출 방식으로 분리하여 안정적인 Bean 생성 구조로 개선

