### PR TITLE
[feat] BookDetailView 도서 상세조회 API 연동 및 없는 ISBN 화면 예외 처리 (#104)

### DIFF
--- a/BookSpace/frontend/src/api/bookApi.js
+++ b/BookSpace/frontend/src/api/bookApi.js
@@ -1,6 +1,5 @@
 // src/api/bookApi.js
-import httpClient from "./httpClient";
-import httpClinet from "./httpClient"; 
+import httpClient from "./httpClient"; 
 
 const BASE = "/books";
 
@@ -9,7 +8,7 @@ const BASE = "/books";
  * GET /books?type=bestseller|new
  */
 export const fetchDefaultBooks = async ({ type = "bestseller" } = {}) => {
-  const res = await httpClinet.get(BASE, {
+  const res = await httpClient.get(BASE, {
     params: { type },
   });
   return res.data; // List<BookSearchResponseDto>
@@ -34,6 +33,21 @@ export const searchBooks = async ({
     },
   });
   return res.data; // List<BookSearchResponseDto>
+};
+
+/**
+ * 도서 상세조회 (ISBN 기반)
+ * GET /books/detail/{isbn}
+ * -> BookDetailResponseDto
+ */
+export const fetchBookDetailByIsbn = async (isbn) => {
+  if (!isbn || !String(isbn).trim()) {
+    throw new Error("isbn is required");
+  }
+  const res = await httpClient.get(
+    `${BASE}/detail/${encodeURIComponent(String(isbn).trim())}`
+  );
+  return res.data; // BookDetailResponseDto
 };
 
 /**

--- a/BookSpace/frontend/src/components/bookDetail/BookDetailInfo.vue
+++ b/BookSpace/frontend/src/components/bookDetail/BookDetailInfo.vue
@@ -21,7 +21,7 @@
     <div v-if="book?.description" class="space-y-2">
       <h2 class="text-xl font-semibold">책 소개</h2>
       <p class="whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
-        {{ book.description }}
+        {{ decodedDescription }}
       </p>
     </div>
 
@@ -36,11 +36,19 @@ import { computed } from "vue";
 const props = defineProps({
   book: {
     type: Object,
-    required: true, // BookSearchResponseDto 그대로 사용
+    required: true,
   },
 });
 
-const formattedPubDate = computed(() => {
-  return props.book?.pubDate || "";
-});
+
+const decodeHtml = (str = "") => {
+  const el = document.createElement("textarea");
+  el.innerHTML = str;
+  return el.value;
+}
+
+// html entity 디코딩 처리
+const decodedDescription = computed(()=>
+  decodeHtml(props.book?.description ?? "")
+);
 </script>

--- a/BookSpace/frontend/src/stores/bookStore.js
+++ b/BookSpace/frontend/src/stores/bookStore.js
@@ -1,9 +1,10 @@
 // src/stores/bookStore.js
 import { defineStore } from "pinia";
-import { fetchDefaultBooks, searchBooks } from "@/api/bookApi";
+import { fetchDefaultBooks, searchBooks, fetchBookDetailByIsbn } from "@/api/bookApi";
 
 export const useBookStore = defineStore("book", {
   state: () => ({
+    // 목록
     books: [],
     loading: false,
     error: null,
@@ -14,6 +15,11 @@ export const useBookStore = defineStore("book", {
     lastSort: "latest",      // latest|popular|accuracy
     lastDefaultType: "bestseller", // bestseller|new
     hasSearched: false,
+
+    // 상세 정보
+    bookDetail: null,
+    loadingDetail: false,
+    detailError: null,
   }),
 
   getters: {
@@ -68,6 +74,39 @@ export const useBookStore = defineStore("book", {
     // 검색어 지우고 기본목록으로 되돌릴 때
     async resetToDefault() {
       await this.loadDefault({ type: this.lastDefaultType || "bestseller" });
+    },
+
+    // 상세 조회
+    async loadBookDetail(isbn) {
+      this.loadingDetail = true;
+      this.detailError = null;
+
+      try {
+        const data = await fetchBookDetailByIsbn(isbn);
+        this.bookDetail = data ?? null;
+      } catch (e) {
+        const status = e?.response?.status;
+
+    if (status === 404) {
+      
+      this.detailError = "NOT_FOUND";
+    } else {
+      this.detailError =
+        e?.response?.data?.message ||
+        "도서 상세 정보를 불러오지 못했습니다.";
+    }
+
+    this.bookDetail = null;
+      } finally {
+        this.loadingDetail = false;
+      }
+    },
+
+    // 상세 초기화 (페이지 이동 시 깔끔하게)
+    clearBookDetail() {
+      this.bookDetail = null;
+      this.detailError = null;
+      this.loadingDetail = false;
     },
   },
 });

--- a/BookSpace/frontend/src/views/BookDetailView.vue
+++ b/BookSpace/frontend/src/views/BookDetailView.vue
@@ -1,6 +1,32 @@
 <template>
   <main class="mx-auto max-w-6xl px-4 py-6">
-    <div class="grid gap-6 md:grid-cols-[240px_1fr]">
+
+    <div v-if="loadingDetail" class="py-10 text-sm text-muted-foreground">
+      상세 정보를 불러오는 중...
+    </div>
+
+    <!-- URL상에서 없는 ISBN 번호로 입력해서 화면이동했을 때 -->
+    <div v-else-if="detailError === 'NOT_FOUND'" class="py-16 text-center">
+      <p class="text-2xl font-medium font-semibold">도서를 찾을 수 없어요</p>
+      <p class="mt-2 text-base text-muted-foreground">
+        ISBN이 잘못되었거나 삭제된 도서일 수 있어요.
+      </p>
+      <div class="mt-6 flex justify-center gap-2">
+        <button class="h-9 rounded-md border px-4 py-1.5" @click="$router.back()">이전으로</button>
+        <button
+          class="h-9 rounded-md bg-primary px-4 py-1.5 text-primary-foreground"
+          @click="$router.push('/books')"
+        >
+        도서 목록으로
+        </button>
+      </div>
+    </div>
+
+    <div v-else-if="detailError" class="py-10 text-sm text-destructive">
+      {{ detailError }}
+    </div>
+
+    <div v-else-if="book" class="grid gap-6 md:grid-cols-[240px_1fr]">
       <!-- LEFT -->
       <aside class="lg:sticky lg:top-6 h-fit">
         <BookSideCard :book="book" :is-wished="isWished" :average-rating="averageRating" :review-count="reviewCount" :post-count="postCount" @toggle-wish="toggleWish" />
@@ -25,11 +51,18 @@
         </ReviewPostTabs>
       </section>
     </div>
+
+    <div v-else class="py-10 text-sm text-muted-foreground">
+      도서 정보를 찾을 수 없습니다.
+    </div>
   </main>
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
+import { useRoute } from "vue-router";
+import { useBookStore } from "@/stores/bookStore";
+
 import BookDetailInfo from "../components/bookDetail/BookDetailInfo.vue";
 import BookSideCard from "@/components/bookDetail/BookSideCard.vue";
 import ReviewPostTabs from "../components/bookDetail/ReviewPostTabs.vue";
@@ -37,29 +70,36 @@ import ReviewPostTabs from "../components/bookDetail/ReviewPostTabs.vue";
 import ReviewSection from "@/components/review/ReviewSection.vue";
 import PostSection from "@/components/postInBookDetail/PostSection.vue";
 
+
 const activeTab = ref("review");
 
-/**
- * 화면 확인용 더미 데이터
- * (BookSearchResponseDto 형태 그대로)
- */
-const book = ref({
-  title: "최소한의 삼국지 - 최태성의 삼국지 고전 특강",
-  author: "최태성 (지은이), 이성원 (감수)",
-  publisher: "프런트페이지",
-  pubDate: "2025-11-18",
-  isbn13: "9791193401583",
-  cover: "https://image.aladin.co.kr/product/37773/21/cover200/k002033562_2.jpg",
-  description: "인생의 필독서로 손꼽히는 ‘삼국지’를 한 권으로 정리한 입문서입니다.",
-});
+const route = useRoute();
+const bookStore = useBookStore();
 
-// UI용 더미 상태
-const isWished = ref(false);
-const averageRating = ref(4.8);
-const reviewCount = ref(12);
-const postCount = ref(3);
+const book = computed(()=> bookStore.bookDetail);
 
+// BookSideCard에 전달
+const isWished = computed(() => !!bookStore.bookDetail?.isWished);
+const averageRating = computed(() => bookStore.bookDetail?.averageRating ?? 0.0);
+const reviewCount = computed(() => bookStore.bookDetail?.reviewCount ?? 0);
+const postCount = computed(() => bookStore.bookDetail?.postCount ?? 0);
+
+const loadingDetail = computed(() => bookStore.loadingDetail);
+const detailError = computed(() => bookStore.detailError);
+
+const load = () => {
+  const isbn = route.params.isbn;
+  if (!isbn) return;
+  bookStore.loadBookDetail(isbn);
+};
+
+onMounted(load);
+// 같은 화면에서 isbn만 바뀌는 경우 대비
+watch(() => route.params.isbn, load);
+
+// 아직 wishAPI 연동 전
 function toggleWish() {
-  isWished.value = !isWished.value;
+  if(!bookStore.bookDetail) return;
+  bookStore.bookDetail.isWished = !bookStore.bookDetail.isWished;
 }
 </script>


### PR DESCRIPTION
## 도서 상세조회 페이지 API 연동 및 예외 처리

### 도서 상세조회 API 연동
- 백엔드 `/books/detail/{isbn}` API와 프론트엔드 연동
- ISBN 기반으로 도서 상세정보를 조회하여 **도서 상세조회 페이지에서 정상적으로 정보 표시**
- 로딩 상태 및 데이터 바인딩을 통해 상세 페이지 렌더링 안정화

### 존재하지 않는 ISBN 예외 처리
- URL에 존재하지 않는 ISBN이 입력된 경우(404)
- 상세 페이지 내에서 **“도서를 찾을 수 없습니다” 안내 화면 노출**
- 사용자 행동을 유도하는 버튼 제공
  - 이전 페이지로 이동
  - 도서 목록 페이지로 이동
