### PR TITLE
[ FE_Edit] BookSearchInput 책 목록 검색 debounce 적용 (#79)

### DIFF
--- a/BookSpace/frontend/src/api/bookApi.js
+++ b/BookSpace/frontend/src/api/bookApi.js
@@ -1,6 +1,5 @@
 // src/api/bookApi.js
 import httpClient from "./httpClient";
-import httpClinet from "./httpClient"; 
 
 const BASE = "/books";
 
@@ -9,7 +8,7 @@ const BASE = "/books";
  * GET /books?type=bestseller|new
  */
 export const fetchDefaultBooks = async ({ type = "bestseller" } = {}) => {
-  const res = await httpClinet.get(BASE, {
+  const res = await httpClient.get(BASE, {
     params: { type },
   });
   return res.data; // List<BookSearchResponseDto>
@@ -26,6 +25,11 @@ export const searchBooks = async ({
 } = {}) => {
   if (!query || !query.trim()) return []; // 빈 검색어 방어
 
+  console.log(query);
+  console.log(type);
+  console.log(sort);
+  console.log(`${BASE}/search`);
+
   const res = await httpClient.get(`${BASE}/search`, {
     params: {
       query: query.trim(),
@@ -33,6 +37,7 @@ export const searchBooks = async ({
       sort,
     },
   });
+  console.log(res.data);
   return res.data; // List<BookSearchResponseDto>
 };
 

--- a/BookSpace/frontend/src/components/book/BookSearchInput.vue
+++ b/BookSpace/frontend/src/components/book/BookSearchInput.vue
@@ -2,16 +2,35 @@
   <!-- 검색기준 + 검색창  -->
   <section class="flex items-center gap-2 mb-4">
     <!-- 책제목, 저자, 출판사 선택 -->
-    <select v-model="type" class="h-9 rounded-md border border-input bg-background px-2 text-xs md:text-sm focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring">
+    <select
+      v-model="type"
+      class="h-9 rounded-md border border-input bg-background px-2 text-xs md:text-sm focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring"
+    >
       <option value="title">제목</option>
       <option value="author">저자</option>
       <option value="publisher">출판사</option>
     </select>
 
     <!-- 검색창 -->
-    <SearchInput v-model="searchQuery" placeholder="검색어를 입력하세요" @search="onSearch" />
+    <SearchInput
+      v-model="searchQuery"
+      placeholder="검색어를 입력하세요"
+      @search="onSearch"
+    />
 
-    <Button class="w-16 h-5 text-white font-extrabold" @click="onSearch">검색</Button>
+    <Button class="w-16 h-5 font-extrabold text-white" @click="onSearch"
+      >검색</Button
+    >
+  </section>
+
+  <!-- 검색 결과 -->
+  <section>
+    <BookSearchResults
+      :query="searchQuery"
+      :results="suggestions"
+      :loading="isLoading"
+      :error="errorMessage"
+    />
   </section>
 </template>
 
@@ -19,6 +38,7 @@
 import { ref, watch } from "vue";
 import SearchInput from "../common/SearchInput.vue";
 import Button from "../ui/Button.vue";
+import BookSearchResults from "./BookSearchResults.vue";
 
 // 초기값
 const props = defineProps({
@@ -33,12 +53,55 @@ const emit = defineEmits(["search"]);
 const searchQuery = ref(props.initialQuery);
 const type = ref(props.initialType);
 
+// 디바운스 타이머
+let debounceTimer = null;
+const DEBOUNCE_DELAY = 300;
+
+// 입력값이 비워있는지 체크
+const wasNonEmpty = ref(searchQuery.value.trim().length > 0);
+
+// 디바운스
+watch([searchQuery, type], ([q, t]) => {
+  const trimmed = q.trim();
+
+  // 이전 디바운스 취소
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+
+  // 입력이 비어있으면 자동 검색 x
+  if (!trimmed) {
+    if (wasNonEmpty.value) {
+      emit("search", {
+        query: "",
+        type: t,
+      });
+    }
+    wasNonEmpty.value = false;
+    return;
+  }
+
+  // 검색어가 있을 경우
+  wasNonEmpty.value = true;
+  //  debounce
+  debounceTimer = setTimeout(() => {
+    emit("search", {
+      query: trimmed,
+      type: type.value,
+    });
+  }, DEBOUNCE_DELAY);
+});
+
 // 검색 확정 : 엔터/버튼 시 부모로 전달
 const onSearch = () => {
-  // 검색어가 공백이면 URL을 바꾸지 않도록 처리
-  const q = searchQuery.value.trim();
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+
   emit("search", {
-    query: q,
+    query: searchQuery.value.trim(), // 빈 값 허용
     type: type.value,
   });
 };
@@ -46,7 +109,10 @@ const onSearch = () => {
 // 뒤로가기/새로고침 등으로 URL이 바뀌면 input도 동기화
 watch(
   () => props.initialQuery,
-  (v) => (searchQuery.value = v ?? "")
+  (v) => {
+    searchQuery.value = v ?? "";
+    wasNonEmpty.value = searchQuery.value.trim().length > 0;
+  }
 );
 watch(
   () => props.initialType,

--- a/BookSpace/frontend/src/components/book/BookSearchResults.vue
+++ b/BookSpace/frontend/src/components/book/BookSearchResults.vue
@@ -1,0 +1,62 @@
+<template>
+  <div v-if="hasQuery" class="p-3 mt-2 border rounded-lg border-border bg-card">
+    <div v-if="loading" class="text-xs text-muted-foreground">검색 중...</div>
+    <div v-else-if="error" class="text-xs text-destructive">
+      {{ error }}
+    </div>
+    <div v-else-if="results.length" class="divide-y divide-border">
+      <RouterLink
+        v-for="book in results"
+        :key="book.bookId || book.isbn13"
+        :to="{ name: 'bookDetail', params: { isbn: book.isbn13 } }"
+        class="flex gap-3 py-2"
+      >
+        <div class="w-10 overflow-hidden rounded h-14 shrink-0 bg-muted">
+          <img
+            :src="book.cover"
+            :alt="book.title"
+            class="object-cover w-full h-full"
+          />
+        </div>
+        <div class="min-w-0 space-y-1">
+          <p class="text-sm font-semibold text-foreground line-clamp-1">
+            {{ book.title }}
+          </p>
+          <p class="text-xs text-muted-foreground line-clamp-1">
+            {{ book.author || "저자 정보 없음" }}
+            <span v-if="book.publisher">· {{ book.publisher }}</span>
+          </p>
+        </div>
+      </RouterLink>
+    </div>
+    <div v-else class="text-xs text-muted-foreground">
+      검색 결과가 없습니다.
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { RouterLink } from "vue-router";
+
+const props = defineProps({
+  query: {
+    type: String,
+    default: "",
+  },
+  results: {
+    type: Array,
+    default: () => [],
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+  error: {
+    type: String,
+    default: "",
+  },
+});
+
+const hasQuery = computed(() => props.query.trim().length > 0);
+</script>

--- a/BookSpace/frontend/src/composables/useBookSearch.js
+++ b/BookSpace/frontend/src/composables/useBookSearch.js
@@ -26,18 +26,23 @@ export function useBookSearch() {
       error.value = "";
 
       try {
+        // 1. 기본 목록 조회 (검색어 없음)
         if (!q) {
-          books.value = await fetchDefaultBooks({ type: "bestseller" });
+          books.value = await fetchDefaultBooks({
+            type: t === "new" ? "new" : "bestseller",
+          });
           return;
         }
 
+        // 2. 검색 조회
         books.value = await searchBooks({
           query: q,
           type: t,
           sort: s,
         });
       } catch (e) {
-        error.value = e?.response?.data?.message || "검색 결과를 불러오지 못했습니다.";
+        error.value =
+          e?.response?.data?.message || "검색 결과를 불러오지 못했습니다.";
         books.value = [];
       } finally {
         loading.value = false;
@@ -50,16 +55,18 @@ export function useBookSearch() {
   const search = ({ query, type }) => {
     const trimmed = (query ?? "").trim();
     if (!trimmed) {
-      router.push({ path: "/books" });
+      router.replace({
+        path: "/books",
+        query: {}, // query 파라미터 제거
+      });
       return;
     }
 
-    router.push({
+    router.replace({
       path: "/books",
       query: {
         query: trimmed,
         type: type ?? "title",
-        sort: "latest",
       },
     });
   };

--- a/BookSpace/frontend/src/views/BooksView.vue
+++ b/BookSpace/frontend/src/views/BooksView.vue
@@ -1,13 +1,22 @@
 <template>
   <!-- 도서목록 클릭하면 초기화되면서 메인 도서 목록으로 돌아오도록 설정 -->
   <RouterLink :to="{ path: '/books' }">
-    <ViewHeader title="도서 목록" description="다양한 책들을 탐색해보세요" align="left" size="lg" />
+    <ViewHeader
+      title="도서 목록"
+      description="다양한 책들을 탐색해보세요"
+      align="left"
+      size="lg"
+    />
   </RouterLink>
 
   <div>
     <!-- 검색창  -->
     <section class="mb-8">
-      <BookSearchInput :initialQuery="query" :initialType="type" @search="search"></BookSearchInput>
+      <BookSearchInput
+        :initialQuery="query"
+        :initialType="type"
+        @search="search"
+      ></BookSearchInput>
     </section>
 
     <!-- 정렬기준 선택 (검색모드일때만 보임)-->
@@ -25,13 +34,23 @@
     <!-- 도서 목록 -->
     <section>
       <!-- 베스트셀러 제목 (검색 아닐 때만) -->
-      <h2 v-if="!isSearchMode" class="mb-8 text-2xl font-semibold">인기 도서</h2>
-      <BookList v-if="!loading && !error && books.length" :books="books"></BookList>
+      <h2 v-if="!isSearchMode" class="mb-8 text-2xl font-semibold">
+        인기 도서
+      </h2>
+      <BookList
+        v-if="!loading && !error && books.length"
+        :books="books"
+      ></BookList>
 
       <!-- 결과 없음 -->
-      <div v-else class="flex min-h-[160px] flex-col items-center justify-center rounded-xl border border-dashed text-sm text-muted-foreground mt-6">
+      <div
+        v-else
+        class="flex min-h-[160px] flex-col items-center justify-center rounded-xl border border-dashed text-sm text-muted-foreground mt-6"
+      >
         {{ isSearchMode ? "검색 결과가 없습니다." : "표시할 도서가 없습니다." }}
-        <span class="mt-1">검색어를 바꿔보거나 다른 조건으로 시도해보세요.</span>
+        <span class="mt-1"
+          >검색어를 바꿔보거나 다른 조건으로 시도해보세요.</span
+        >
       </div>
     </section>
   </div>
@@ -46,7 +65,17 @@ import BookSortBar from "../components/book/BookSortBar.vue";
 import { useBookSearch } from "@/composables/useBookSearch";
 import { RouterLink } from "vue-router";
 
-const { query, type, sort, isSearchMode, books, loading, error, search, changeSort } = useBookSearch();
+const {
+  query,
+  type,
+  sort,
+  isSearchMode,
+  books,
+  loading,
+  error,
+  search,
+  changeSort,
+} = useBookSearch();
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
## PR Summary

- **Type**: Edit
- **Scope**: FE(comment)
- **Issue**:  #79 

---

## 작업 내용

### Frontend

1. **BookSearchInput 유저 입력 변화에 따른 디바운스 검색 트리거 추가**
- emit("search") 기반으로 BooksView와 연결하고, URL 쿼리(query/type/sort)로 상태 유지
- useBookSearch composable로 URL 기반 fetch/정렬 로직을 한 곳으로 정리
검색어 없으면 기본 목록 조회 / 있으면 검색 결과 조회
검색 / 정렬 변경 시 router query 갱신 및 자동 refetch

### Backend

- N/A

---

## How to Test
- 도서 메뉴 > 검색 인풋 > 제목/저자/출판사 검색 동작 확인
- 엔터/버튼 클릭 검색 확인
- 새로고침/뒤로가기 시 입력값/상태 동기화 확인
- 정렬 변경 시 재조회 확인

---

##    후속 작업
- community > post Create에 도서 검색 적용