### PR TITLE
[BE_Edit] Book 도메인 알라딘 도서 검색 결과 필터링 로직 추가 ( BookServiceImpl) (#79)

### DIFF
--- a/BookSpace/backend/.idea/compiler.xml
+++ b/BookSpace/backend/.idea/compiler.xml
@@ -8,16 +8,8 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.34/ec547ef414ab1d2c040118fb9c1c265ada63af14/lombok-1.18.34.jar" />
         </processorPath>
-        <module name="bookspace.test" />
-      </profile>
-      <profile name="Gradle Imported" enabled="true">
-        <outputRelativeToContentRoot value="true" />
-        <processorPath useClasspath="false">
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.34/ec547ef414ab1d2c040118fb9c1c265ada63af14/lombok-1.18.34.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.mapstruct/mapstruct-processor/1.5.5.Final/897f6f115930b936287bef552bf5fe28cc64717d/mapstruct-processor-1.5.5.Final.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-configuration-processor/3.4.0/fc571725ca8b92a09a48ccce8ab1547464b0bd8b/spring-boot-configuration-processor-3.4.0.jar" />
-        </processorPath>
         <module name="bookspace.main" />
+        <module name="bookspace.test" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/service/BookServiceImpl.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.bookspace.domain.book.converter.BookConverter;
 
 
-import java.awt.print.Book;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 @Service
@@ -115,18 +115,95 @@ public class BookServiceImpl implements BookService {
     }
 
     // 알라딘 API로만 책 조회 (3개의 파라미터)
+    // searchType에 따라 알라딘 api 조회 결과 부정확함
+    // -> 서버에서 searchType별로
+    // query와 일치하는 도서 -> query로 시작하는 도서의 순으로 최대 3권 반환
     @Override
-    public List<BookSearchResponseDto> searchBooksFromAladin(String query, String searchType, String sort) {
+    public List<BookSearchResponseDto> searchBooksFromAladin(String query, String searchType,   String sort) {
+
+        final int maxResults = 100;
+
         AladinListResponseDto apiResponse =
-                aladinClient.searchBooks(query, searchType, sort, 100);
+                aladinClient.searchBooks(query, searchType, sort, maxResults);
 
         if (apiResponse == null || apiResponse.getItems() == null) {
             return List.of();
         }
 
-        return apiResponse.getItems().stream()
+        String normalizedQuery = normalize(query);
+        if (normalizedQuery.isEmpty()) {
+            return List.of();
+        }
+
+        List<AladinItemResponseDto> items = apiResponse.getItems();
+
+        // 중복 제거 + 순서 유지 (equals 결과 먼저, 그 다음 startsWith 결과)
+        LinkedHashSet<AladinItemResponseDto> result = new LinkedHashSet<>();
+
+        // 1) equals 우선
+        for (AladinItemResponseDto item : items) {
+            String target = normalize(extractTarget(item, searchType));
+            if (!target.isEmpty() && target.equals(normalizedQuery)) {
+                result.add(item);
+            }
+        }
+
+        // 2) startsWith
+        for (AladinItemResponseDto item : items) {
+            String target = normalize(extractTarget(item, searchType));
+            if (!target.isEmpty() && target.startsWith(normalizedQuery)) {
+                result.add(item);
+            }
+        }
+
+        return result.stream()
                 .map(BookConverter::toSearchResponseFromAladinItem)
                 .toList();
+    }
+
+    /**
+     * 비교용 정규화:
+     * - 괄호/대괄호 내용 제거: (개정판), [세트] 등
+     * - 특수문자 제거
+     * - 공백 정리
+     * - 소문자 변환
+     */
+    private String normalize(String raw) {
+        if (raw == null) return "";
+
+        String s = raw.trim().toLowerCase();
+
+        // () [] 안 내용 제거
+        s = s.replaceAll("\\(.*?\\)", " ");
+        s = s.replaceAll("\\[.*?\\]", " ");
+
+        // 한글/영문/숫자/공백만 남김
+        s = s.replaceAll("[^\\p{IsAlphabetic}\\p{IsDigit}\\p{IsHangul}\\s]", " ");
+
+        // 공백 정규화
+        return s.replaceAll("\\s+", " ").trim();
+    }
+
+
+    /**
+     * 검색 타입에 따라 비교 대상 문자열 추출
+     */
+    private String extractTarget(AladinItemResponseDto item, String searchType) {
+        String raw =  switch(searchType.toLowerCase()){
+            case "title" -> item.getTitle();
+            case "author" -> item.getAuthor();
+            case "publisher" -> item.getPublisher();
+            default -> null;
+        };
+
+        if (raw == null) return null;
+
+        int idx = raw.indexOf("(");
+        if (idx > 0) {
+            raw = raw.substring(0, idx);
+        }
+
+        return raw.trim();
     }
 
     /**


### PR DESCRIPTION
## PR Summary

- **Type**:  Edit
- **Scope**: BE(search)
- **Issue**:  #79 / Refs #

---

## 작업 내용
알라딘 api 검색 정확도를 높이기 위해 정규화 ( normalize) + equals -> startsWith 우선순위 필터링 및 중복제거 적용

### Frontend
- N/A

### Backend
**1. 알라딘 검색 결과 필터링 (query/type/sort)**
-   최대 100개 조회 후 서버에서  query와 정확히 일치하는 항목 우선 (equals) ->  query로 시작하는 항목을 다음 우선순위 적용 (startsWith)
- LinkedHashWet으로 중복 제고 + 결과 순서 유지
- 정규화 로직 추가 (normalize)
공백 정리, 소문자 변현환, () / [] 구간 제거
