### PR TITLE
[Edit] 게시글 작성/ 수정 도서 검색 디바운스 적용 및 검색 결과 표시 (#79)

### DIFF
--- a/BookSpace/frontend/src/components/book/BookSearchInput.vue
+++ b/BookSpace/frontend/src/components/book/BookSearchInput.vue
@@ -22,23 +22,12 @@
       >검색</Button
     >
   </section>
-
-  <!-- 검색 결과 -->
-  <section>
-    <BookSearchResults
-      :query="searchQuery"
-      :results="suggestions"
-      :loading="isLoading"
-      :error="errorMessage"
-    />
-  </section>
 </template>
 
 <script setup>
 import { ref, watch } from "vue";
 import SearchInput from "../common/SearchInput.vue";
 import Button from "../ui/Button.vue";
-import BookSearchResults from "./BookSearchResults.vue";
 
 // 초기값
 const props = defineProps({

--- a/BookSpace/frontend/src/components/book/BookSearchResults.vue
+++ b/BookSpace/frontend/src/components/book/BookSearchResults.vue
@@ -1,15 +1,29 @@
 <template>
+  <!-- 검색어 있으면 결과 영역 -->
   <div v-if="hasQuery" class="p-3 mt-2 border rounded-lg border-border bg-card">
-    <div v-if="loading" class="text-xs text-muted-foreground">검색 중...</div>
+    <div v-if="loading" class="p-3 text-xs text-muted-foreground">
+      검색 중...
+    </div>
     <div v-else-if="error" class="text-xs text-destructive">
       {{ error }}
     </div>
-    <div v-else-if="results.length" class="divide-y divide-border">
-      <RouterLink
-        v-for="book in results"
+    <!-- 검색 결과 목록 -->
+    <div
+      v-else-if="limitedResults.length"
+      class="divide-y divide-border"
+      :class="containerClass"
+      :style="containerStyle"
+    >
+      <!-- 각 책을 버튼으로 렌더링 -> 클릭 시 부모로 select 이벤트 전달 -->
+      <button
+        v-for="book in limitedResults"
         :key="book.bookId || book.isbn13"
-        :to="{ name: 'bookDetail', params: { isbn: book.isbn13 } }"
-        class="flex gap-3 py-2"
+        type="button"
+        class="flex w-full gap-3 p-4 text-left transition rounded-md hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        :class="{
+          'bg-muted/60 ring-1 ring-ring': book.isbn13 === selectedIsbn,
+        }"
+        @click="emit('select', book)"
       >
         <div class="w-10 overflow-hidden rounded h-14 shrink-0 bg-muted">
           <img
@@ -18,6 +32,7 @@
             class="object-cover w-full h-full"
           />
         </div>
+        <!-- 책 정보 -->
         <div class="min-w-0 space-y-1">
           <p class="text-sm font-semibold text-foreground line-clamp-1">
             {{ book.title }}
@@ -27,8 +42,9 @@
             <span v-if="book.publisher">· {{ book.publisher }}</span>
           </p>
         </div>
-      </RouterLink>
+      </button>
     </div>
+    <!-- 검색 결과가 없을 경우 -->
     <div v-else class="text-xs text-muted-foreground">
       검색 결과가 없습니다.
     </div>
@@ -37,13 +53,17 @@
 
 <script setup>
 import { computed } from "vue";
-import { RouterLink } from "vue-router";
 
+const emit = defineEmits(["select"]);
+
+// 현재 검색어 (공백이면 결과ui 숨기기)
 const props = defineProps({
+  // 검색어
   query: {
     type: String,
     default: "",
   },
+  // 서버애서 받아온 검색 결과
   results: {
     type: Array,
     default: () => [],
@@ -56,7 +76,37 @@ const props = defineProps({
     type: String,
     default: "",
   },
+  maxResults: {
+    type: Number,
+    default: 0,
+  },
+  selectedIsbn: {
+    type: String,
+    default: "",
+  },
+  maxHeight: {
+    type: String,
+    default: "",
+  },
 });
 
+// 검색어가 존재하는지
 const hasQuery = computed(() => props.query.trim().length > 0);
+
+// 최대 개수 제한 있으면 slice
+const limitedResults = computed(() =>
+  props.maxResults > 0
+    ? props.results.slice(0, props.maxResults)
+    : props.results
+);
+
+// maxHeight -> 스크롤 허용
+const containerClass = computed(() =>
+  props.maxHeight ? "overflow-y-auto pr-1" : ""
+);
+
+// maxHeight (inline style)
+const containerStyle = computed(() =>
+  props.maxHeight ? { maxHeight: props.maxHeight } : undefined
+);
 </script>

--- a/BookSpace/frontend/src/components/community/PostBookInfo.vue
+++ b/BookSpace/frontend/src/components/community/PostBookInfo.vue
@@ -1,0 +1,55 @@
+<!-- 게시글 작성 / 수정 뷰에서 책 정보 간략하게 보여주는 ui -->
+<template>
+  <div class="space-y-3">
+    <Separator />
+    <div class="flex items-start gap-4 px-1">
+      <div class="h-40 overflow-hidden rounded-md w-28 bg-muted">
+        <img
+          :src="displayImage"
+          :alt="title || 'book cover'"
+          class="object-cover w-full h-full"
+        />
+      </div>
+      <div class="flex-1 space-y-1">
+        <p class="text-lg font-semibold text-foreground">
+          {{ title || "도서 정보 없음" }}
+        </p>
+        <p class="text-sm text-muted-foreground">
+          {{ author || "작성자가 도서 정보를 추가하지 않았어요." }}
+        </p>
+        <p v-if="isbn" class="text-xs text-muted-foreground">ISBN {{ isbn }}</p>
+      </div>
+    </div>
+    <Separator />
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import Separator from "@/components/ui/Separator.vue";
+
+const props = defineProps({
+  title: {
+    type: String,
+    default: "",
+  },
+  author: {
+    type: String,
+    default: "",
+  },
+  isbn: {
+    type: String,
+    default: "",
+  },
+  imageUrl: {
+    type: String,
+    default: "",
+  },
+  defaultImage: {
+    type: String,
+    default: "/default-book.png",
+  },
+});
+
+const displayImage = computed(() => props.imageUrl || props.defaultImage);
+</script>

--- a/BookSpace/frontend/src/components/post/PostBookSelector.vue
+++ b/BookSpace/frontend/src/components/post/PostBookSelector.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="space-y-2">
+    <div class="flex items-center justify-between">
+      <label class="text-sm font-semibold text-foreground">책 선택</label>
+    </div>
+
+    <!-- 책 검색 입력 인풋 -->
+    <BookSearchInput @search="handleSearch" />
+
+    <!-- 검색 결과  -->
+    <BookSearchResults
+      v-if="showResults"
+      :query="lastQuery"
+      :results="results"
+      :loading="loading"
+      :error="error"
+      :selected-isbn="isbn"
+      :max-results="0"
+      max-height="16rem"
+      @select="handleSelect"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import BookSearchInput from "@/components/book/BookSearchInput.vue";
+import BookSearchResults from "@/components/book/BookSearchResults.vue";
+import { useInlineBookSearch } from "@/composables/useInlineBookSearch";
+
+const props = defineProps({
+  isbn: {
+    type: String,
+    default: "",
+  },
+});
+
+const emit = defineEmits(["update:isbn", "select"]);
+
+const { results, loading, error, lastQuery, search } = useInlineBookSearch();
+const showResults = ref(true);
+
+const handleSearch = ({ query, type }) => {
+  showResults.value = true;
+  search({ query, type });
+};
+
+const handleSelect = (book) => {
+  const isbn13 = book?.isbn13 ?? "";
+  emit("update:isbn", isbn13);
+  emit("select", book);
+  showResults.value = false;
+};
+</script>

--- a/BookSpace/frontend/src/composables/useInlineBookSearch.js
+++ b/BookSpace/frontend/src/composables/useInlineBookSearch.js
@@ -1,0 +1,58 @@
+import { ref } from "vue";
+import { searchBooks } from "@/api/bookApi";
+
+/**
+ *  게시물 작성 / 수정 뷰에서 책 검색 전용
+ */
+export function useInlineBookSearch() {
+  const results = ref([]);
+  const loading = ref(false);
+  const error = ref("");
+  const lastQuery = ref("");
+  const lastType = ref("title");
+
+  const search = async ({ query, type = "title" } = {}) => {
+    const trimmed = (query ?? "").trim(); // 검색어 정규화
+    lastQuery.value = trimmed;
+    lastType.value = type ?? "title";
+    error.value = "";
+
+    // 검색어가 없으면 결과 초기화
+    if (!trimmed) {
+      results.value = [];
+      return;
+    }
+
+    loading.value = true;
+    try {
+      // 서버 책 검색 API 호출
+      const data = await searchBooks({
+        query: trimmed,
+        type: lastType.value,
+      });
+      results.value = Array.isArray(data) ? data : [];
+    } catch (e) {
+      error.value =
+        e?.response?.data?.message || "검색 결과를 불러오지 못했습니다.";
+      results.value = [];
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  //  검색 결과 초기화
+  const clear = () => {
+    results.value = [];
+    error.value = "";
+  };
+
+  return {
+    results,
+    loading,
+    error,
+    lastQuery,
+    lastType,
+    search,
+    clear,
+  };
+}

--- a/BookSpace/frontend/src/views/PostCreateUpdateView.vue
+++ b/BookSpace/frontend/src/views/PostCreateUpdateView.vue
@@ -1,5 +1,3 @@
-<!-- TODO 검색 기능: 책 검색 (알라딘 api 조회 후) -> isbn으로 서버에 보내기-->
-<!--TODO 스타일 수정  -->
 <template>
   <ViewHeader
     :title="headerTitle"
@@ -12,18 +10,57 @@
     class="max-w-4xl p-6 mt-6 space-y-6 border shadow-sm rounded-xl bg-card border-border"
   >
     <form class="space-y-6" @submit.prevent="handleSubmit">
-      <div class="space-y-2">
-        <div class="flex items-center justify-between">
-          <label class="text-sm font-semibold text-foreground"> 책 선택 </label>
-          <!-- <span class="text-xs text-muted-foreground"> BookSpace </span> -->
+      <!-- 책 선택 -->
+      <div class="space-y-3">
+        <div class="flex items-center justify-end">
+          <!-- 작성 모드에서만 다시 선택 가능 -->
+          <Button
+            v-if="
+              !isEditMode &&
+              selectedBook &&
+              selectedBook.isbn &&
+              !showBookSelector
+            "
+            type="button"
+            variant="ghost"
+            size="sm"
+            @click="showBookSelector = true"
+          >
+            다시 선택
+          </Button>
         </div>
-        <SearchInput
-          v-model="isbn"
-          placeholder="책 제목을 검색하세요"
-          @search="onSearch"
-        />
+
+        <!-- 수정 모드: 책 변경 불가 -->
+        <template v-if="isEditMode">
+          <PostBookInfo
+            v-if="selectedBook"
+            :title="selectedBook.title"
+            :author="selectedBook.author"
+            :isbn="selectedBook.isbn"
+            :image-url="selectedBook.imageUrl"
+          />
+        </template>
+
+        <!-- 작성 모드 -->
+        <template v-else>
+          <PostBookSelector
+            v-if="showBookSelector"
+            v-model:isbn="isbn"
+            @select="onBookSelect"
+          />
+
+          <div v-if="selectedBook && !showBookSelector" class="pt-1">
+            <PostBookInfo
+              :title="selectedBook.title"
+              :author="selectedBook.author"
+              :isbn="selectedBook.isbn"
+              :image-url="selectedBook.imageUrl"
+            />
+          </div>
+        </template>
       </div>
 
+      <!-- 제목 -->
       <div class="space-y-2">
         <label class="text-sm font-semibold text-foreground">제목</label>
         <Input
@@ -34,6 +71,7 @@
         />
       </div>
 
+      <!-- 내용 -->
       <div class="space-y-2">
         <label class="text-sm font-semibold text-foreground">내용</label>
         <Textarea
@@ -44,10 +82,12 @@
         />
       </div>
 
+      <!-- 버튼 -->
       <div class="flex items-center justify-between gap-3 pt-2">
         <p v-if="errorMessage" class="text-sm text-destructive">
           {{ errorMessage }}
         </p>
+
         <div class="flex items-center gap-2 ml-auto">
           <Button
             type="button"
@@ -57,6 +97,7 @@
           >
             취소
           </Button>
+
           <Button
             type="submit"
             :disabled="!isFormValid || isSubmitting || isEditLoading"
@@ -75,9 +116,10 @@ import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import ViewHeader from "@/components/common/ViewHeader.vue";
 import Button from "@/components/ui/Button.vue";
-import SearchInput from "../components/common/SearchInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Textarea from "@/components/ui/Textarea.vue";
+import PostBookSelector from "@/components/post/PostBookSelector.vue";
+import PostBookInfo from "@/components/community/PostBookInfo.vue";
 import { createPostApi, fetchPostDetail, updatePostApi } from "@/api/postApi";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
 
@@ -100,12 +142,51 @@ const postContent = ref("");
 const errorMessage = ref("");
 const isSubmitting = ref(false);
 
-const isFormValid = computed(() => {
+// 수정 모드 - 수정 여부 체크
+const originalTitle = ref("");
+const originalContent = ref("");
+
+const selectedBook = ref(null);
+const showBookSelector = ref(true);
+
+/**
+ * 수정 모드
+ * - 게시물 제목, 내용이 바뀌었는지 체크
+ */
+const isPostChanged = computed(() => {
+  if (!isEditMode.value) return true;
+
+  const trimmedTitle = postTitle.value.trim();
+  const trimmedContent = postContent.value.trim();
+
   return (
-    !!postTitle.value.trim() &&
-    !!postContent.value.trim() &&
-    !!isbn.value.trim()
+    trimmedTitle !== (originalTitle.value || "").trim() ||
+    trimmedContent !== (originalContent.value || "").trim()
   );
+});
+
+/**
+ * 작성 모드
+ * - 필수 값 체크
+ */
+const hasRequiredFieldsForCreate = computed(() => {
+  return (
+    !!isbn.value.trim() &&
+    !!postTitle.value.trim() &&
+    !!postContent.value.trim()
+  );
+});
+
+/*
+ * 버튼 활성화 조건
+ * - 작성 모드: 필수값 필요
+ * - 수정 모드: 제목 or 내용 변경 시에만 활성화
+ *  */
+const isFormValid = computed(() => {
+  if (isEditMode.value) {
+    return isPostChanged.value;
+  }
+  return hasRequiredFieldsForCreate.value;
 });
 
 const headerTitle = computed(() =>
@@ -120,6 +201,7 @@ const submitLabel = computed(() =>
   isEditMode.value ? "수정 완료" : "게시글 등록"
 );
 
+// 수정 데이터 로드
 const { data: detailData, isLoading: isEditLoading } = useQuery({
   queryKey: ["post", postId.value],
   queryFn: () => fetchPostDetail(postId.value),
@@ -132,13 +214,29 @@ watch(
   () => detailData.value,
   (val) => {
     if (!isEditMode.value || !val) return;
+
     isbn.value = val.isbn || "";
     postTitle.value = val.postTitle || "";
     postContent.value = val.postContent || "";
+
+    originalTitle.value = val.postTitle || "";
+    originalContent.value = val.postContent || "";
+
+    selectedBook.value = {
+      title: val.bookTitle || "",
+      author: val.bookAuthor || "",
+      isbn: val.isbn || "",
+      imageUrl: val.bookImageUrl || "",
+    };
+
+    showBookSelector.value = false;
   },
   { immediate: true }
 );
 
+/**
+ * 게시글 생성
+ */
 const createPostMutation = useMutation({
   mutationFn: (payload) => createPostApi(payload),
   onSuccess: async () => {
@@ -146,13 +244,11 @@ const createPostMutation = useMutation({
     await queryClient.invalidateQueries({ queryKey: ["posts", "latest"] });
     router.push({ name: "community" });
   },
-  onError: (error) => {
-    errorMessage.value =
-      error?.response?.data?.message ||
-      "게시글 등록에 실패했습니다. 잠시 후 다시 시도해주세요.";
-  },
 });
 
+/**
+ * 게시글 수정
+ */
 const updatePostMutation = useMutation({
   mutationFn: (payload) => updatePostApi(postId.value, payload),
   onSuccess: async () => {
@@ -161,42 +257,28 @@ const updatePostMutation = useMutation({
     await queryClient.invalidateQueries({ queryKey: ["post", postId.value] });
     router.push({ name: "postDetail", params: { postId: postId.value } });
   },
-  onError: (error) => {
-    errorMessage.value =
-      error?.response?.data?.message ||
-      "게시글 수정에 실패했습니다. 잠시 후 다시 시도해주세요.";
-  },
 });
 
+/**
+ * 버튼 클릭
+ */
 const handleSubmit = async () => {
   errorMessage.value = "";
 
-  const trimmedIsbn = isbn.value.trim();
   const trimmedTitle = postTitle.value.trim();
   const trimmedContent = postContent.value.trim();
 
-  if (!trimmedIsbn) {
-    errorMessage.value = "ISBN을 입력해주세요.";
-    return;
-  }
-  if (!trimmedTitle || !trimmedContent) {
-    errorMessage.value = "제목과 내용을 입력해주세요.";
-    return;
-  }
-
   isSubmitting.value = true;
   try {
-    // 게시글 수정
-    if (isEditMode.value && postId.value) {
+    if (isEditMode.value) {
       await updatePostMutation.mutateAsync({
-        isbn: trimmedIsbn,
+        isbn: isbn.value, // 수정 시 기존 isbn 유지
         postTitle: trimmedTitle,
         postContent: trimmedContent,
       });
     } else {
-      // 게시글 작성
       await createPostMutation.mutateAsync({
-        isbn: trimmedIsbn,
+        isbn: isbn.value.trim(),
         postTitle: trimmedTitle,
         postContent: trimmedContent,
       });
@@ -205,4 +287,26 @@ const handleSubmit = async () => {
     isSubmitting.value = false;
   }
 };
+
+/**
+ * 책 선택
+ */
+const onBookSelect = (book) => {
+  isbn.value = book?.isbn13 ?? "";
+  selectedBook.value = {
+    title: book?.title || "",
+    author: book?.author || "",
+    isbn: isbn.value,
+    imageUrl: book?.cover || "",
+  };
+  showBookSelector.value = false;
+};
+
+watch(
+  isEditMode,
+  (val) => {
+    if (val) showBookSelector.value = false;
+  },
+  { immediate: true }
+);
 </script>

--- a/BookSpace/frontend/src/views/PostDetailView.vue
+++ b/BookSpace/frontend/src/views/PostDetailView.vue
@@ -39,41 +39,25 @@
         </header>
 
         <div class="space-y-4">
+          <!-- 게시글 제목 -->
           <h1 class="text-2xl font-semibold text-foreground">
             {{ post.postTitle }}
           </h1>
 
-          <div class="space-y-3">
-            <Separator />
-            <div class="flex items-start gap-4 px-1">
-              <div class="h-40 overflow-hidden rounded-md w-28 bg-muted">
-                <img
-                  :src="post.bookImageUrl || defaultBook"
-                  alt="book cover"
-                  class="object-cover w-full h-full"
-                />
-              </div>
-              <div class="flex-1 space-y-1">
-                <p class="text-lg font-semibold text-foreground">
-                  {{ post.bookTitle || "도서 정보 없음" }}
-                </p>
-                <p class="text-sm text-muted-foreground">
-                  {{
-                    post.bookAuthor || "작성자가 도서 정보를 추가하지 않았어요."
-                  }}
-                </p>
-                <p v-if="post.isbn" class="text-xs text-muted-foreground">
-                  ISBN {{ post.isbn }}
-                </p>
-              </div>
-            </div>
-            <Separator />
-          </div>
+          <!-- 책 정보 -->
+          <PostBookInfo
+            :title="post.bookTitle"
+            :author="post.bookAuthor"
+            :isbn="post.isbn"
+            :image-url="post.bookImageUrl"
+          />
         </div>
 
+        <!-- 게시글 내용 -->
         <p class="leading-relaxed whitespace-pre-line text-foreground">
           {{ content }}
         </p>
+
         <!-- 좋아요 & 댓굴 & 조회 -->
         <div
           class="flex items-center justify-end w-full gap-3 text-sm flex- text-muted-foreground"
@@ -137,7 +121,6 @@ import { useRouter, onBeforeRouteUpdate } from "vue-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
 import Button from "@/components/ui/Button.vue";
 import { useToast } from "@/composables/useToast";
-import Separator from "@/components/ui/Separator.vue";
 import {
   deleteLikes,
   deletePostApi,
@@ -151,6 +134,7 @@ import { useUserStore } from "@/stores/userStore";
 import CommentsSection from "@/components/community/CommentsSection.vue";
 import UserProfileImg from "@/components/common/UserProfileImg.vue";
 import KebabMenu from "@/components/community/KebabMenu.vue";
+import PostBookInfo from "@/components/community/PostBookInfo.vue";
 
 const { toast } = useToast();
 
@@ -194,9 +178,6 @@ const formattedDate = computed(() => {
 });
 
 const content = computed(() => post.value?.postContent ?? "");
-
-const defaultProfile = "/default-profile.png";
-const defaultBook = "/default-book.png";
 
 const goBack = () => {
   router.push({


### PR DESCRIPTION
## PR Summary

- **Type**: edit
- **Scope**: FE(search)
- **Issue**:  #79  / Refs #

---

## 작업 내용

### Frontend

**1. 게시글 작성 / 수정 도서 검색 디바운스 적용 및 검색 결과 표시**
- `userInlineBookSearch` composable 추가
페이지 이동 없이 책 검색 가능
검색 결과 / 로딩 / 에러 상태 렌더링
- BookSearchResults 컴포넌트 개선
최대 개수 제한 (maxResults) 지원 및 검색 결과 스크롤

**2. 게시글 update 조건 수정**
- 수정 모드에서 게시글 등록했을 때 선택한 도서 변경 불가
- 수정 모드에서  postTitle, postContent 중 하나에 변경사항이 있을 때만 '수정 완료'버튼 활성화 및 서버 요청 전송
- 작성 모드 & 수정 모드 유효성 검증 로직 분리
작성 모드 : 모든 필드가 채워졌을 떄
수정 모드:  postTitle, postContent 중 하나에 변경사항이 있을 때

**3. 컴포넌트 추가 (components > community)**
- PostBookInfo로 책 상세 조회 및 게시글 작성/수정 화면에서 책 정보 렌더링


### Backend

- N/A

---

## How to Test
1. 게시글 작성 시 도서 검색 -> 선택 -> 게시글 작성 시 등록 여부 체크
2. 도서 검색 결과가 최대 지정 개수만큼 나오는지 체크
3. 게시글 수정 시 제목 또는 내용 변경 시에만 수정 버튼 활성화 여부 체크
4. 수정모드에서 도서 변경 불가 확인
5. 게시글 작성 / 수정에서 검색어 삭제 시 검색 결과 초기화 여부 체크

