### PR TITLE
[feat] 도서 상세 리뷰 등록 API 연동 (#110)

### DIFF
--- a/BookSpace/backend/.idea/modules.xml
+++ b/BookSpace/backend/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/bookspace.main.iml" filepath="$PROJECT_DIR$/.idea/modules/bookspace.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/bookspace.test.iml" filepath="$PROJECT_DIR$/.idea/modules/bookspace.test.iml" />
     </modules>
   </component>
 </project>

--- a/BookSpace/backend/.idea/modules/bookspace.test.iml
+++ b/BookSpace/backend/.idea/modules/bookspace.test.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test" isTestSource="true" generated="true" />
+    </content>
+  </component>
+</module>

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/controller/ReviewController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/controller/ReviewController.java
@@ -80,17 +80,18 @@ public class ReviewController {
         return ResponseEntity.ok(reviewService.getReviewsByBookId(bookId, sort));
     }
 
-    // 7. 특정 책의 평균 평점 조회
-    // /reviews/avg-rating?bookId=10
-    @GetMapping("/avg-rating")
-    public ResponseEntity<Double> getAverageRating(@RequestParam long bookId) {
-        return ResponseEntity.ok(reviewService.getAverageRatingByBookId(bookId));
-    }
-
-    // 8. 특정 책의 리뷰 개수 조회
-    // /reviews/count?bookId=10
-    @GetMapping("/count")
-    public ResponseEntity<Integer> getReviewCount(@RequestParam long bookId) {
-        return ResponseEntity.ok(reviewService.getReviewCountByBookId(bookId));
-    }
+    // BookService로 넘겨서 BookDetailResponseDTO쪽에서 사용
+//    // 7. 특정 책의 평균 평점 조회
+//    // /reviews/avg-rating?bookId=10
+//    @GetMapping("/avg-rating")
+//    public ResponseEntity<Double> getAverageRating(@RequestParam long bookId) {
+//        return ResponseEntity.ok(reviewService.getAverageRatingByBookId(bookId));
+//    }
+//
+//    // 8. 특정 책의 리뷰 개수 조회
+//    // /reviews/count?bookId=10
+//    @GetMapping("/count")
+//    public ResponseEntity<Integer> getReviewCount(@RequestParam long bookId) {
+//        return ResponseEntity.ok(reviewService.getReviewCountByBookId(bookId));
+//    }
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/service/ReviewServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/service/ReviewServiceImpl.java
@@ -28,15 +28,23 @@ public class ReviewServiceImpl implements ReviewService {
 
         String isbn = dto.getIsbn();
 
-        // 예외 처리
-        // 1. rating 범위 유효성 검사 (0~5) => 400 BAD_REQUEST
-        if (dto.getReviewRating() < 0 || dto.getReviewRating() > 5) {
-            throw new RuntimeException("Rating must be between 0 and 5.");
+        // isbn 없는 경우 예외처리
+        if (isbn == null || isbn.isBlank()) {
+            throw new RuntimeException("isbn is null or empty");
         }
 
-        // 2. 소수점 한 자리까지 허용
-        if (Math.round(dto.getReviewRating() * 10) != dto.getReviewRating() * 10) {
-            throw new RuntimeException("Rating must have at most one decimal place.");
+
+        // 평점 예외 처리
+        // 1. rating 범위 유효성 검사 (0.5~5.0) => 400 BAD_REQUEST
+        double rating = dto.getReviewRating();
+
+        if (rating < 0.5 || rating > 5.0) {
+            throw new RuntimeException("Rating must be between 0.0 and 5.0.");
+        }
+
+        // 2. 0.5 단위만 허용
+        if (Math.abs(rating * 2 - Math.round(rating * 2)) > 1e-9) {
+            throw new RuntimeException("Rating must be in 0.5 increments.");
         }
 
         // isbn 기반 DB 책 정보 확인 및 저장

--- a/BookSpace/backend/src/main/java/com/bookspace/global/exception/GlobalExceptionHandler.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.bookspace.global.exception;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -25,6 +26,16 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleNotFound(IllegalArgumentException ex) {
         return ErrorResponse.builder()
                 .code("NOT_FOUND")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    /** 403 - Forbidden (권한 없음: 작성자 본인만 수정/삭제 가능) */
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ErrorResponse handleAccessDenied(AccessDeniedException ex) {
+        return ErrorResponse.builder()
+                .code("FORBIDDEN")
                 .message(ex.getMessage())
                 .build();
     }

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
@@ -79,6 +79,11 @@ public class SecurityConfig {
                                 "/books/**"
                         ).permitAll() // 인증 없이 가능
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/posts/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/reviews/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/reviews").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/reviews/**").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/reviews/**").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/reviews/**").authenticated()
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated() // 나머지 요청은 jwt가 필요함
                 )

--- a/BookSpace/frontend/src/api/reviewApi.js
+++ b/BookSpace/frontend/src/api/reviewApi.js
@@ -1,0 +1,73 @@
+import httpClient from "./httpClient";
+
+/**
+ * 리뷰 API
+ * - 조회: 비로그인 가능
+ * - 작성/수정/삭제: 로그인 필요
+ * - 별점: 0.5 단위
+ * - 리뷰 작성은 isbn 기반
+ */
+
+
+/**
+ * 리뷰 목록 조회 (도서 기준)
+ * GET /reviews?bookId=10&sort=latest
+ */
+export const getReviewsByBookIdApi = (bookId, sort = "latest") => {
+  return httpClient
+    .get("/reviews", {
+      params: { bookId, sort },
+    })
+    .then((res) => res.data); // List<ReviewResponseDto>
+};
+
+/**
+ * 리뷰 목록 조회 (by userId))
+ * GET /reviews?userId=3&sort=latest
+ */
+export const getReviewsByUserIdApi = (userId, sort = "latest") => {
+  return httpClient
+    .get("/reviews", {
+      params: { userId, sort },
+    })
+    .then((res) => res.data); // List<ReviewResponseDto>
+};
+
+/**
+ * 리뷰 단건 조회
+ * GET /reviews/{reviewId}
+ */
+export const getReviewByIdApi = (reviewId) => {
+  return httpClient.get(`/reviews/${reviewId}`).then((res) => res.data);
+};
+
+
+/**
+ * 리뷰 작성
+ * POST /reviews
+ * payload: { isbn, reviewRating, reviewContent }
+ */
+export const createReviewApi = (payload) => {
+  return httpClient.post("/reviews", payload).then((res) => res.data);
+};
+
+/**
+ * 리뷰 수정 (작성자 본인만 가능)
+ * PUT /reviews/{reviewId}
+ * payload: { reviewRating, reviewContent }
+ */
+export const updateReviewApi = (reviewId, payload) => {
+  return httpClient
+    .put(`/reviews/${reviewId}`, payload)
+    .then((res) => res.data);
+};
+
+/**
+ * 리뷰 삭제 (작성자 본인만 가능)
+ * DELETE /reviews/{reviewId}
+ */
+export const deleteReviewApi = (reviewId) => {
+  return httpClient
+    .delete(`/reviews/${reviewId}`)
+    .then((res) => res.data);
+};

--- a/BookSpace/frontend/src/components/review/ReviewCreate.vue
+++ b/BookSpace/frontend/src/components/review/ReviewCreate.vue
@@ -7,7 +7,7 @@
       <p class="text-base font-normal mb-2">평점</p>
 
       <!-- 접힌 상태에서도 별점 선택 가능 -->
-      <div>
+      <div class="review-interactive" @click="blockIfNotLoggedIn" @mousedown="blockIfNotLoggedIn">
         <StarRating v-model="rating" :step="0.5" :showValue="true" />
       </div>
     </div>
@@ -24,7 +24,8 @@
           rows="1"
           class="flex-1 h-10 overflow-hidden rounded-md border border-input bg-background px-4 py-2 text-sm outline-none placeholder:text-muted-foreground resize-none transition-all duration-200 ease-out"
           placeholder="이 책에 대한 생각을 자유롭게 적어주세요"
-          @click="expand"
+          @click="handleTextareaClick"
+          @focus="handleTextareaClick"
         ></textarea>
 
         <!-- 접힌 상태 버튼
@@ -35,7 +36,7 @@
           type="button"
           class="h-10 shrink-0 rounded-md px-5 text-sm font-semibold text-white disabled:opacity-60"
           :class="canSubmit ? 'bg-primary hover:bg-primary/90' : 'bg-gray-400'"
-          :disabled="props.isSubmitting"
+          :disabled="reviewStore.submitting"
           @click="onSubmitCollapsed"
         >
           등록
@@ -49,6 +50,7 @@
           :maxlength="maxLength"
           class="mt-3 w-full h-[160px] rounded-md border border-input bg-background p-4 text-sm outline-none focus-visible:ring-[3px] focus-visible:border-primary focus-visible:ring-ring/50 placeholder:text-muted-foreground resize-none"
           placeholder="이 책에 대한 생각을 자유롭게 적어주세요 (최대 300자)"
+          @click="blockIfNotLoggedIn"
         ></textarea>
 
         <div class="mt-2 flex justify-between">
@@ -71,14 +73,37 @@
 
 <script setup>
 import { computed, nextTick, ref } from "vue";
+import { useReviewStore } from "@/stores/reviewStore";
+import { useAuthStore } from "@/stores/authStore";
+import { useBookStore } from "@/stores/bookStore";
 import StarRating from "../ui/StarRating.vue";
 
+const authStore = useAuthStore();
+const bookStore = useBookStore();
+const isLoggedIn = computed(()=> authStore.isLoggedIn);
+
+function blockIfNotLoggedIn(e) {
+  if (isLoggedIn.value) return;
+
+  // 리뷰 작성 인터렉션 영역에서 막기
+  const isInInteractive = e?.target?.closest?.(".review-interactive");
+  if (!isInInteractive) return;
+
+  // 포커스/클릭/드래그 등 입력 자체를 원천 차단
+  e.preventDefault?.();
+  e.stopPropagation?.();
+
+  alert("로그인 후 이용 가능한 서비스입니다");
+}
+
+
 const props = defineProps({
+  bookId: { type: Number, required: true },
+  isbn: { type: String, required: true },
   maxLength: { type: Number, default: 300 },
-  isSubmitting: { type: Boolean, default: false },
 });
 
-const emit = defineEmits(["submit"]);
+const reviewStore = useReviewStore();
 
 const rating = ref(0);
 const content = ref("");
@@ -92,9 +117,21 @@ const expand = async () => {
   await nextTick();
 };
 
-// 리뷰 작성 API(emit) 호출 로직은 하나로 통일
-function submitReview(payloadContent) {
-  if (props.isSubmitting) return;
+// textarea 클릭 핸들러
+const handleTextareaClick = (e) => {
+  if (!isLoggedIn.value) {
+    e.preventDefault();
+    e.stopPropagation();
+    alert("로그인 후 이용 가능한 서비스입니다");
+    e.target.blur(); // 포커스 제거
+    return;
+  }
+  expand();
+};
+
+// 공통 제출 로직
+async function submitReview(payloadContent) {
+  if (reviewStore.submitting) return;
 
   // 별점 선택 안했을시
   if (rating.value === 0) {
@@ -102,14 +139,38 @@ function submitReview(payloadContent) {
     return;
   }
 
-  emit("submit", {
-    rating: rating.value,
-    content: payloadContent, // null 또는 string
-  });
+  try {
+    await reviewStore.createReview(
+      {
+        isbn: props.isbn,
+        reviewRating: rating.value, // 0.5 단위
+        reviewContent: payloadContent, // null 또는 string
+      },
+      {
+        refreshBookId: props.bookId, // 작성 후 목록 갱신
+        sort: "latest",
+      }
+    );
 
-  // 공통 초기화
-  content.value = "";
-  rating.value = 0;
+    // 책 상세 정보 갱신 (평점, 리뷰 개수 업데이트)
+    await bookStore.loadBookDetail(props.isbn);
+
+    alert("리뷰가 등록되었습니다.");
+
+    // 공통 초기화
+    content.value = "";
+    rating.value = 0;
+  } catch (e) {
+    const status = e?.response?.status;
+
+    if (status === 401) {
+      alert("로그인 후 이용 가능한 서비스입니다");
+    } else if (status === 403) {
+      alert("작성자만 수정/삭제할 수 있습니다");
+    } else {
+      alert(e?.response?.data?.message ?? "리뷰 등록에 실패했습니다");
+    }
+  }
 }
 
 // 접힌 상태: 별점만 등록
@@ -118,8 +179,8 @@ function onSubmitCollapsed() {
 }
 
 // 펼친 상태: 별점 + 내용 등록 후 다시 접힘
-function onSubmitExpanded() {
-  submitReview(content.value.trim() || null);
+async function onSubmitExpanded() {
+  await submitReview(content.value.trim() || null);
 
   // 펼친 상태에서 등록 후 다시 접힘
   isExpanded.value = false;

--- a/BookSpace/frontend/src/components/review/ReviewSection.vue
+++ b/BookSpace/frontend/src/components/review/ReviewSection.vue
@@ -1,42 +1,43 @@
 <template>
   <div class="space-y-6">
-    <ReviewCreate></ReviewCreate>
+    <!-- 리뷰 작성 폼 -->
+    <ReviewCreate :book-id="bookId" :isbn="isbn"></ReviewCreate>
+
+    <!-- 리뷰 목록 -->
     <ReviewList :reviews="reviews"></ReviewList>
   </div>
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { computed, onMounted, watch } from "vue";
+import { useReviewStore } from "@/stores/reviewStore";
 import ReviewCreate from "./ReviewCreate.vue";
 import ReviewList from "./ReviewList.vue";
 
-// defineProps({
-//   reviews: { type: Array, default: () => [] },
-// });
+const props = defineProps({
+  bookId: { type: Number, required: true },
+  isbn: { type: String, required: true },
+});
 
-const reviews = ref([
-  {
-    reviewId: 1,
-    nickname: "독서왕",
-    reviewDate: "2025-12-17T10:23:11",
-    reviewRating: 4.5,
-    reviewContent: "생각보다 훨씬 몰입해서 읽었어요.\n삼국지를 처음 접하는 사람에게 정말 좋은 입문서라고 느꼈습니다.",
-  },
-  {
-    reviewId: 2,
-    nickname: "책벌레",
-    reviewDate: "2025-12-15T21:10:03",
-    reviewRating: 4.0,
-    reviewContent: "내용 정리가 잘 되어 있어서 읽기 편했어요.\n다만 이미 삼국지를 알고 있다면 조금 단순하게 느껴질 수도 있을 것 같아요.",
-  },
-  {
-    reviewId: 3,
-    nickname: "초보독자",
-    reviewDate: "2025-12-14T08:42:55",
-    reviewRating: 5.0,
-    reviewContent: "삼국지 이름만 알고 있었는데 이 책 덕분에 전체 흐름을 이해할 수 있었어요!\n강의 듣는 느낌이라 재밌었습니다.",
-  },
-]);
+const reviewStore = useReviewStore();
+const reviews = computed(() => reviewStore.reviewsByBook);
+
+const fetch = async () => {
+  // 일단 sort는 latest로 고정
+  await reviewStore.fetchReviewsByBookId(props.bookId, "latest");
+};
+
+onMounted(fetch);
+
+// bookId가 바뀌는 경우(다른 상세로 이동) 대비
+watch(
+  () => props.bookId,
+  async (newVal, oldVal) => {
+    if (!newVal || newVal === oldVal) return;
+    await fetch();
+  }
+);
+
 </script>
 
 <style scoped></style>

--- a/BookSpace/frontend/src/stores/reviewStore.js
+++ b/BookSpace/frontend/src/stores/reviewStore.js
@@ -1,0 +1,151 @@
+import { defineStore } from "pinia";
+import {
+  getReviewsByBookIdApi,
+  getReviewsByUserIdApi,
+  getReviewByIdApi,
+  createReviewApi,
+  updateReviewApi,
+  deleteReviewApi,
+} from "@/api/reviewApi";
+
+export const useReviewStore = defineStore("review", {
+  state: () => ({
+    // 도서 상세: bookId 기준 리뷰 목록
+    reviewsByBook: [],
+    loadingByBook: false,
+
+    // 마이페이지: userId 기준 리뷰 목록
+    reviewsByUser: [],
+    loadingByUser: false,
+
+    // 리뷰 단건 (필요 시)
+    reviewDetail: null,
+    loadingDetail: false,
+
+    // 작성 / 수정 / 삭제 공통
+    submitting: false,
+  }),
+
+  getters: {
+    reviewCountByBook(state) {
+      return state.reviewsByBook.length;
+    },
+    reviewCountByUser(state) {
+      return state.reviewsByUser.length;
+    },
+  },
+
+  actions: {
+    // 1. 리뷰 목록 조회 by bookId
+    async fetchReviewsByBookId(bookId, sort = "latest") {
+      this.loadingByBook = true;
+      try {
+        const data = await getReviewsByBookIdApi(bookId, sort);
+        this.reviewsByBook = Array.isArray(data) ? data : [];
+        return this.reviewsByBook;
+      } finally {
+        this.loadingByBook = false;
+      }
+    },
+
+    // 2. 리뷰 목록 조회 by userId
+    async fetchReviewsByUserId(userId, sort = "latest") {
+      this.loadingByUser = true;
+      try {
+        const data = await getReviewsByUserIdApi(userId, sort);
+        this.reviewsByUser = Array.isArray(data) ? data : [];
+        return this.reviewsByUser;
+      } finally {
+        this.loadingByUser = false;
+      }
+    },
+
+    // 3. 리뷰 단건 조회 by reviewId
+    async fetchReviewById(reviewId) {
+      this.loadingDetail = true;
+      try {
+        const data = await getReviewByIdApi(reviewId);
+        this.reviewDetail = data ?? null;
+        return this.reviewDetail;
+      } finally {
+        this.loadingDetail = false;
+      }
+    },
+
+    // 4. 리뷰 작성
+    async createReview(payload, { refreshBookId, sort = "latest" } = {}) {
+      this.submitting = true;
+      try {
+        const data = await createReviewApi(payload);
+
+        // 작성 후 도서 리뷰 목록 갱신
+        if (refreshBookId) {
+          await this.fetchReviewsByBookId(refreshBookId, sort);
+        }
+
+        return data;
+      } finally {
+        this.submitting = false;
+      }
+    },
+
+    // 5. 리뷰 수정
+    async updateReview(
+      reviewId,
+      payload,
+      { refreshBookId, refreshUserId, sort = "latest" } = {}
+    ) {
+      this.submitting = true;
+      try {
+        const data = await updateReviewApi(reviewId, payload);
+
+        if (refreshBookId) {
+          await this.fetchReviewsByBookId(refreshBookId, sort);
+        }
+        if (refreshUserId) {
+          await this.fetchReviewsByUserId(refreshUserId, sort);
+        }
+
+        return data;
+      } finally {
+        this.submitting = false;
+      }
+    },
+
+    // 6. 리뷰 삭제
+    async deleteReview(
+      reviewId,
+      { refreshBookId, refreshUserId, sort = "latest" } = {}
+    ) {
+      this.submitting = true;
+      try {
+        const data = await deleteReviewApi(reviewId);
+
+        if (refreshBookId) {
+          await this.fetchReviewsByBookId(refreshBookId, sort);
+        }
+        if (refreshUserId) {
+          await this.fetchReviewsByUserId(refreshUserId, sort);
+        }
+
+        return data;
+      } finally {
+        this.submitting = false;
+      }
+    },
+
+    // 7. 상태 초기화
+    reset() {
+      this.reviewsByBook = [];
+      this.loadingByBook = false;
+
+      this.reviewsByUser = [];
+      this.loadingByUser = false;
+
+      this.reviewDetail = null;
+      this.loadingDetail = false;
+
+      this.submitting = false;
+    },
+  },
+});

--- a/BookSpace/frontend/src/views/BookDetailView.vue
+++ b/BookSpace/frontend/src/views/BookDetailView.vue
@@ -49,7 +49,7 @@
         <ReviewPostTabs v-model="activeTab" :review-count="reviewCount" :post-count="postCount">
           <!-- ReviewSection -->
           <template #review>
-            <ReviewSection />
+            <ReviewSection :book-id="book.bookId" :isbn="book.isbn"/>
           </template>
 
           <!-- PostSection -->


### PR DESCRIPTION
## 주요 변경사항

### 1. 리뷰 등록 기능 구현
- 도서 상세 화면에서 별점 및 리뷰 내용을 입력해 리뷰를 등록할 수 있도록 구현
- 별점은 0.5 단위로 입력 가능하도록 처리 (0.5 ~ 5.0)

### 2. 비로그인 사용자 리뷰 작성 차단
- 로그인하지 않은 사용자가 리뷰 작성을 시도할 경우 차단
- 별점 선택 및 리뷰 입력 시 로그인 여부를 먼저 확인
- 비로그인 상태에서는 "로그인 후 이용 가능한 서비스입니다" 안내 메시지 노출

### 3. 리뷰 등록 후 실시간 화면 갱신
- 리뷰 등록 후 페이지 새로고침 없이 리뷰 목록 자동 갱신
- 새로 작성한 리뷰가 즉시 목록에 반영되도록 개선
- 리뷰 개수 및 평점 정보도 함께 업데이트

### 4. 리뷰 작성 UX 개선
- 별점 선택 후 바로 등록 가능하도록 UI 구성
- 리뷰 내용을 입력할 경우 입력 영역이 자연스럽게 확장되는 구조 적용
- 등록 중 중복 요청을 방지하도록 처리

### 5. 안정성 및 예외 처리 보강
- 인증이 필요한 리뷰 등록/수정/삭제 API는 SecurityConfig에서 인증 필수로 설정
- 401 / 403 / 400 응답에 따른 사용자 안내 메시지 분기 처리





