### PR TITLE
[FE_Feat] CommunityView > Post 검색 결과 및 정 기능 추가 및 비로그인 유저 답글 작성 ui 숨김 …

### DIFF
--- a/BookSpace/frontend/src/api/postApi.js
+++ b/BookSpace/frontend/src/api/postApi.js
@@ -22,15 +22,21 @@ export const createPostApi = async (payload) => {
 };
 
 /**
- *  [R] 게시글 전체 조회 (페이징)
+ *  [R] 게시글 전체 조회 & 게시글 검색(페이징)
  * @param {*} param0
  * @returns
  */
-export const fetchPosts = async ({ pageParam = 0 }) => {
+export const fetchPosts = async ({
+  pageParam = 0,
+  isbn = "",
+  sort = "latest",
+} = {}) => {
   const res = await httpClient.get("/posts", {
     params: {
       page: pageParam,
       size: 10,
+      isbn: isbn || undefined,
+      sort: sort || undefined,
     },
   });
 

--- a/BookSpace/frontend/src/components/book/BookSearchInput.vue
+++ b/BookSpace/frontend/src/components/book/BookSearchInput.vue
@@ -1,8 +1,32 @@
+<!--
+# SearchBar (공통 컴포넌트)
+- CommunityView, BooksView 검색 UI
+- Select(검색 기준) + Input (검색 입력) + Button
+- 입력값/타입 변경 & 엔터/버튼 클릭시 300ms emit("search") 발생
+- api 호출, 검색 결과 렌더링은 부모 컴포넌트에서 수행
+
+[props]
+- initialQuery: 검색 인풋 초기값
+- initialType: 셀러터 초기값
+- showTypeSelector: 검색 기준 노출 여부 (post검색에서는 검색 기준 x -> 책 제목만임)
+- placholder: input placeholder
+
+[사용]
+<BookSearchInput
+  :initialQuery="route.query.q ?? ''"
+  :initialType="route.query.type ?? 'title'"
+  :showTypeSelector="true"
+  placeholder="책 제목/저자/출판사로 검색"
+  @search="handleSearch"
+/>
+
+-->
 <template>
   <!-- 검색기준 + 검색창  -->
   <section class="flex items-center gap-2 mb-4">
     <!-- 책제목, 저자, 출판사 선택 -->
     <select
+      v-if="showTypeSelector"
       v-model="type"
       class="h-9 rounded-md border border-input bg-background px-2 text-xs md:text-sm focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring"
     >
@@ -14,7 +38,7 @@
     <!-- 검색창 -->
     <SearchInput
       v-model="searchQuery"
-      placeholder="검색어를 입력하세요"
+      :placeholder="placeholder"
       @search="onSearch"
     />
 
@@ -33,6 +57,8 @@ import Button from "../ui/Button.vue";
 const props = defineProps({
   initialQuery: { type: String, default: "" },
   initialType: { type: String, default: "title" },
+  showTypeSelector: { type: Boolean, default: true },
+  placeholder: { type: String, default: "검색어를 입력하세요" },
 });
 
 // 부모 BooksView에게 전달할 이벤트들

--- a/BookSpace/frontend/src/components/community/CommentItem.vue
+++ b/BookSpace/frontend/src/components/community/CommentItem.vue
@@ -57,7 +57,7 @@
         </div>
         <!-- 답글 작성 버튼 -->
         <button
-          v-if="isParent && !isEditing"
+          v-if="isParent && !isEditing && isLoggedIn"
           class="text-xs text-primary hover:underline"
           type="button"
           @click="$emit('reply', comment.commentId)"
@@ -120,6 +120,8 @@ const authStore = useAuthStore();
 const userStore = useUserStore();
 const queryClient = useQueryClient();
 const { toast } = useToast();
+
+const isLoggedIn = computed(() => authStore.isLoggedIn);
 
 // ------------ owner? ------------
 const me = computed(() => userStore.me);

--- a/BookSpace/frontend/src/components/community/CommentsSection.vue
+++ b/BookSpace/frontend/src/components/community/CommentsSection.vue
@@ -65,7 +65,10 @@
         @comment-deleted="handleCommentDeleted"
       >
         <!-- 답글 -->
-        <template #replyArea v-if="replyTargetId === comment.commentId">
+        <template
+          #replyArea
+          v-if="authStore.isLoggedIn && replyTargetId === comment.commentId"
+        >
           <div
             class="p-4 mt-2 space-y-3 border rounded-lg bg-muted/40 border-border"
           >
@@ -228,6 +231,7 @@ const submitReply = async () => {
 };
 
 const activateReply = (commentId) => {
+  if (!ensureAuth()) return;
   replyTargetId.value = commentId;
   replyText.value = "";
   errorMessage.value = "";

--- a/BookSpace/frontend/src/components/community/PostSortBar.vue
+++ b/BookSpace/frontend/src/components/community/PostSortBar.vue
@@ -1,0 +1,39 @@
+<template>
+  <section class="flex justify-end gap-4 mb-4 text-sm">
+    <button
+      type="button"
+      :class="[
+        'transition',
+        sort === 'latest'
+          ? 'font-semibold text-primary'
+          : 'text-muted-foreground hover:text-foreground',
+      ]"
+      @click="emit('sort-change', 'latest')"
+    >
+      최신순
+    </button>
+    <button
+      type="button"
+      :class="[
+        'transition',
+        sort === 'comments'
+          ? 'font-semibold text-primary'
+          : 'text-muted-foreground hover:text-foreground',
+      ]"
+      @click="emit('sort-change', 'comments')"
+    >
+      인기순
+    </button>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  sort: {
+    type: String,
+    default: "latest",
+  },
+});
+
+const emit = defineEmits(["sort-change"]);
+</script>

--- a/BookSpace/frontend/src/components/post/PostBookSelector.vue
+++ b/BookSpace/frontend/src/components/post/PostBookSelector.vue
@@ -1,11 +1,35 @@
+<!-- 
+# PostBookSelector
+ Commuityview에서 post 작성/수정 폼에서 책 검색(BookSearchInput) -> 결과 표시(BookSearchResults) -> 책 선택(composable/useInlineBookSearch) 
+- BookSearchInput: 유저가 검색어 입력 -> emit("search", { query, type }) -> handleSearch
+- BookSearchResults: useInlineBookSearch().search({query, type}) 결과 전달
+
+[사용]
+  <PostBookSelector
+    v-model:isbn="isbn"
+    :titleOnly="true"
+    label="책 선택"
+    placeholder="책 제목을 입력하세요"
+    @select="onSelectBook"
+  />
+-->
+
 <template>
   <div class="space-y-2">
-    <div class="flex items-center justify-between">
-      <label class="text-sm font-semibold text-foreground">책 선택</label>
+    <div v-if="showLabel" class="flex items-center justify-between">
+      <label class="text-sm font-semibold text-foreground">
+        {{ label }}
+      </label>
     </div>
 
     <!-- 책 검색 입력 인풋 -->
-    <BookSearchInput @search="handleSearch" />
+    <BookSearchInput
+      :initial-query="initialQuery"
+      :initial-type="titleOnly ? 'title' : initialType"
+      :show-type-selector="!titleOnly"
+      :placeholder="placeholder"
+      @search="handleSearch"
+    />
 
     <!-- 검색 결과  -->
     <BookSearchResults
@@ -33,14 +57,49 @@ const props = defineProps({
     type: String,
     default: "",
   },
+  titleOnly: {
+    type: Boolean,
+    default: false,
+  },
+  initialQuery: {
+    type: String,
+    default: "",
+  },
+  initialType: {
+    type: String,
+    default: "title",
+  },
+  label: {
+    type: String,
+    default: "책 선택",
+  },
+  showLabel: {
+    type: Boolean,
+    default: true,
+  },
+  placeholder: {
+    type: String,
+    default: "책 제목을 입력하세요",
+  },
 });
 
-const emit = defineEmits(["update:isbn", "select"]);
+const emit = defineEmits(["update:isbn", "select", "clear"]);
 
 const { results, loading, error, lastQuery, search } = useInlineBookSearch();
 const showResults = ref(true);
 
 const handleSearch = ({ query, type }) => {
+  const trimmed = (query ?? "").trim();
+
+  // 인풋이 비워지면 필터 해제
+  if (!trimmed) {
+    if (props.isbn) {
+      emit("update:isbn", "");
+      emit("Clear");
+    }
+    showResults.value = false;
+    return;
+  }
   showResults.value = true;
   search({ query, type });
 };

--- a/BookSpace/frontend/src/views/CommunityView.vue
+++ b/BookSpace/frontend/src/views/CommunityView.vue
@@ -1,5 +1,3 @@
-<!-- TODO SearchInput 검색 기능 -->
-<!-- TODO 스타일 수정 -->
 <template>
   <ViewHeader
     title="커뮤니티"
@@ -9,15 +7,30 @@
   />
 
   <!-- 검색인풋 + 게시글 작성 버튼 -->
-  <section
-    ref="searchAreaRef"
-    class="flex items-center justify-between gap-4 mt-6 mb-4"
-  >
-    <SearchInput placeholder="게시판 검색..." />
+  <section ref="searchAreaRef" class="mt-6 mb-4 space-y-3">
+    <div
+      class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between"
+    >
+      <div class="flex-1 w-full">
+        <PostBookSelector
+          v-model:isbn="selectedIsbn"
+          title-only
+          :show-label="false"
+          placeholder="책 제목으로 게시판을 검색하세요"
+          @select="handleBookSelect"
+        />
+      </div>
 
-    <Button @click="goToCreatePost">
-      <PlusIcon class="w-5 h-5 text-white" /> 게시글 작성
-    </Button>
+      <Button @click="goToCreatePost">
+        <PlusIcon class="w-5 h-5 text-white" /> 게시글 작성
+      </Button>
+    </div>
+
+    <PostSortBar
+      v-if="isSearchMode"
+      :sort="sort"
+      @sort-change="handleSortChange"
+    />
   </section>
 
   <!-- 새 게시글 알림 -->
@@ -77,7 +90,8 @@
 
 <script setup>
 import ViewHeader from "../components/common/ViewHeader.vue";
-import SearchInput from "../components/common/SearchInput.vue";
+import PostBookSelector from "@/components/post/PostBookSelector.vue";
+import PostSortBar from "@/components/community/PostSortBar.vue";
 import Button from "../components/ui/Button.vue";
 import { PlusIcon } from "lucide-vue-next";
 import { ArrowUpIcon } from "@heroicons/vue/24/solid";
@@ -94,9 +108,16 @@ const route = useRoute();
 const router = useRouter();
 const { toast } = useToast();
 
-// 1. 쿼리에서 목록 상태 복원 (스크롤 복원 위치)
-const page = computed(() => Number(route.query.page ?? 0));
-const keyword = computed(() => route.query.keyword ?? "");
+const pickQueryString = (value) =>
+  Array.isArray(value) ? value[0] ?? "" : value ?? "";
+const normalizeSort = (value) =>
+  value === "comments" ? "comments" : "latest";
+
+// 검색/필터 상태
+const selectedIsbn = ref(pickQueryString(route.query.isbn));
+const selectedBookTitle = ref(pickQueryString(route.query.bookTitle));
+const sort = ref(normalizeSort(pickQueryString(route.query.sort)));
+const isSearchMode = computed(() => !!selectedIsbn.value);
 
 // 게시글 목록 경로: data.pages[0].content.posts
 // 2. 게시글 목록 조회
@@ -108,8 +129,21 @@ const {
   status,
   refetch,
 } = useInfiniteQuery({
-  queryKey: ["posts"],
-  queryFn: fetchPosts,
+  queryKey: computed(() => [
+    "posts",
+    {
+      isbn: selectedIsbn.value || null,
+      sort: isSearchMode.value ? sort.value : null,
+    },
+  ]),
+  queryFn: ({ pageParam = 0, queryKey }) => {
+    const [, params] = queryKey;
+    return fetchPosts({
+      pageParam,
+      isbn: params?.isbn || "",
+      sort: isSearchMode.value ? params?.sort || "latest" : undefined,
+    });
+  },
   staleTime: 0, // 항상 stale 처리  -> 최신 데이터 가져오기
   refetchOnWindowFocus: true, // 탭 전환할 때 자동 리패치
   cacheTime: 30000, // 30초 후 캐시 제거
@@ -140,8 +174,22 @@ onMounted(() => {
 
 // 최신 게시글 감지용 쿼리 (첫 페이지만 주기적으로 조회)
 const { data: latestPageData } = useQuery({
-  queryKey: ["posts", "latest"],
-  queryFn: () => fetchPosts({ pageParam: 0 }),
+  queryKey: computed(() => [
+    "posts",
+    "latest",
+    {
+      isbn: selectedIsbn.value || null,
+      sort: isSearchMode.value ? sort.value : null,
+    },
+  ]),
+  queryFn: ({ queryKey }) => {
+    const [, , params] = queryKey;
+    return fetchPosts({
+      pageParam: 0,
+      isbn: params?.isbn || "",
+      sort: isSearchMode.value ? params?.sort || "latest" : undefined,
+    });
+  },
   refetchInterval: 10000, // 10초마다 새 게시글 여부 확인
   refetchOnWindowFocus: true,
   staleTime: 0,
@@ -220,6 +268,47 @@ onUnmounted(() => {
     searchAreaObserver.unobserve(searchAreaRef.value);
   }
 });
+
+// 검색 / 필터 유틸
+const resetScrollState = () => {
+  pendingScroll.value = null;
+  hasRestoredScroll.value = false;
+  isRestoringScroll.value = false;
+  sessionStorage.removeItem("communityScroll");
+};
+
+const syncSearchQueryParams = () => {
+  router.replace({
+    query: {
+      ...route.query,
+      isbn: selectedIsbn.value || undefined,
+      bookTitle: selectedIsbn.value ? selectedBookTitle.value || undefined : undefined,
+      sort: isSearchMode.value ? sort.value || undefined : undefined,
+    },
+  });
+};
+
+const handleBookSelect = async (book) => {
+  selectedIsbn.value = book?.isbn13 ?? "";
+  selectedBookTitle.value = book?.title ?? "";
+  sort.value = normalizeSort(sort.value);
+  resetScrollState();
+  syncSearchQueryParams();
+  await nextTick();
+  await refetch();
+  window.scrollTo({ top: 0, behavior: "smooth" });
+};
+
+const handleSortChange = async (nextSort) => {
+  const normalized = normalizeSort(nextSort);
+  if (sort.value === normalized) return;
+  sort.value = normalized;
+  resetScrollState();
+  syncSearchQueryParams();
+  await nextTick();
+  await refetch();
+  window.scrollTo({ top: 0, behavior: "smooth" });
+};
 
 const goToCreatePost = () => {
   if (!authStore.isLoggedIn) {


### PR DESCRIPTION
## PR Summary

* **Type**: feat
* **Scope**: FE(posts)
* **Issue**:  #79 / Refs #

---

## 작업 내용

### Frontend

1. **게시글 검색 (CommunityView)**

* 책 제목 입력 → 검색 결과 선택 → ISBN 기반으로 게시글 필터링
* 선택된 ISBN으로 커뮤니티 게시글 목록 무한 스크롤 렌더링
* 필터 상태 URL 쿼리스트링 동기화(`isbn`, `bookTitle`)로 새로고침/뒤로가기에도 유지
* 필터 변경 시 목록/스크롤 상태 초기화 및 첫 페이지 재조회(refetch)

2. **책 검색 UI (components > book)**

* `BookSearchInput` 기반 검색 입력 UX 구성
* 검색 결과 선택 컴포넌트와 연동하여 선택된 책 ISBN을 상위로 전달

3. **게시물 정렬 UI (components > community > PostSortBar)**

* 최신순 / 인기순(댓글 많은 순) Post Seach Bar UI 제공 (components > community)
* 정렬 변경 시 `sort-change` 이벤트로 상위 컴포넌트가 목록 재조회 트리거

4. **[보완] 답글 작성 로그인 유저만**

* 비로그인 유저는 답글 버튼 미노출로 액션 제한(권한 기반 UI 제어)

### Backend

* N/A

---

## How to Test

1. 커뮤니티 페이지 진입
2. 책 제목 검색 -> 검색 결과에서 책 선택
3. 선택된 책에 대한 게시글만 노출되는지 체크
4. 스크롤 다운 시 다음 페이지가 정상적으로 로드되는지 체크(무한 스크롤)
5. 정렬 버튼(최신순/인기순) 클릭 후 목록 순서가 변경되는지 체크
6. 비로그인 상태에서 답글 버튼이 보이지 않는지 체크
7. 로그인 후 답글 버튼이 정상 노출되는지 체크
