### PR TITLE
[BE_EDIT] GET /posts isbn 기반 검색 및 정렬 기능 추가 (#79)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
@@ -36,12 +36,20 @@ public class PostController {
     }
 
     // 2. 전체 조회 (페이지네이션 적용)
+    /**
+     * 1) 게시물 전체 조회 & 도서 검색에 대한 게시물 필터링
+     * -  /posts?page=0&size=10 -> 전체 목록
+     * - /posts?page=0&size=10&isbn=978... -> 해당 책 게시글만
+     * 2) 게시글 검색 정렬 (sort)
+     */
     @GetMapping
     public ResponseEntity<PostPageResponseDto> getAllPosts(@RequestParam(defaultValue = "0") int page,
                                                                  @RequestParam(defaultValue = "10") int size,
+                                                           @RequestParam(required = false) String isbn,
+                                                           @RequestParam(required = false,defaultValue = "latest") String sort,
                                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails != null ? userDetails.getUserId() : null;
-        PostPageResponseDto response = postService.getAllPosts(page,size,userId);
+        PostPageResponseDto response = postService.getAllPosts(page,size,isbn,sort, userId);
         return ResponseEntity.ok(response);
     }
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/dao/PostDao.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/dao/PostDao.java
@@ -16,11 +16,12 @@ public interface PostDao {
     int insertPost(PostVo postVo);
 
     // 2. 게시글 전체 조회 (로그인 userId -> isLiked)
-    // 페이징 목록
+    // params: size, offset, userId, isbn
     List<PostResponseDto> selectAllPosts(Map<String,Object> params);
 
-    // 전체 게시물 개수
-    int countAllPosts();
+    // 전체 게시물 / 검색된 게시물 개수
+    // isbn == null ? 전체 카운트 : 필터 카운트
+    int countAllPosts(@Param("isbn") String isbn);
 
     // 3. 게시글 단건 조회 (로그인 userId -> isLiked)
     PostResponseDto selectPostById(@Param("postId") long postId, @Param("userId") Long userId);

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostService.java
@@ -11,8 +11,8 @@ public interface PostService {
     // 게시글 등록
     void createPost(PostRequestDto requestDto, long loginUserId);
 
-    // 게시글 전체 조회 (페이지네이션 적용)
-    PostPageResponseDto getAllPosts(int page, int size, Long userId);
+    // 게시글 전체 조회 &  게시물 검색 (페이지네이션 적용) + 정렬 (sort: latest / comments)
+    PostPageResponseDto getAllPosts(int page, int size, String isbn, String sort, Long userId);
 
     // 게시글 단건 조회
     PostResponseDto getPostById(long postId, Long userId);

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import com.bookspace.domain.book.service.BookService;
 import com.bookspace.domain.post.dto.PostPageResponseDto;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +25,6 @@ public class PostServiceImpl implements PostService {
 
     private final PostDao postDao;
     private final BookService bookService;
-    private final ParameterNamesModule parameterNamesModule;
 
     // 게시글 작성 (isbn)
     @Override
@@ -65,25 +63,36 @@ public class PostServiceImpl implements PostService {
 
 
     /*
-    모든 게시글 조회 (페이지네이션 적용)
+    모든 게시글 조회 (isbn numm) & 게시글 검색 (isbn) - 페이지네이션
     모든 게시물 조회는 게시물 좋아요 개수, 좋아요 여부 2개가 모두 포함된 응답이 옴
     - 로그인한 유저라면, 자신이 게시물을 좋아요 눌렀는지 여부 (full heart / empty heart)
     - 로그인한 유저라면, liked값이 모두 false로 옴 -> 프론트 처리 (empty heart를 유저가 누르려고 시도했을 때 로그인 하라고 하기)
      */
     @Override
-    public PostPageResponseDto getAllPosts(int page, int size, Long userId)
+    public PostPageResponseDto getAllPosts(int page, int size, String isbn,String sort, Long userId)
     {
-
+        int safePage = Math.max(page,0);
+        int safeSize = Math.min(Math.max(size,0),30);
         int offset = page * size;
+
+        String trimmedIsbn = (isbn == null || isbn.isBlank()) ? null : isbn.trim();
+
+        String normalizedSort = (sort == null) ? "lastest":sort.trim().toLowerCase();
+        if(!normalizedSort.equals("latest")&& !normalizedSort.equals("comments")){
+            normalizedSort = "latest";
+
+        }
 
         Map<String, Object> params = new HashMap<>();
         params.put("size", size);
         params.put("offset", offset);
         params.put("userId", userId);
+        params.put("isbn", trimmedIsbn); // isbn이 있으면 넣기
+        params.put("sort", normalizedSort);
 
         List<PostResponseDto> posts = postDao.selectAllPosts(params);
 
-        int totalCount = postDao.countAllPosts();
+        int totalCount = postDao.countAllPosts(trimmedIsbn);
 
         boolean hasNext = (page + 1) * size < totalCount;
         Integer nextPage = hasNext ? page + 1 : null;
@@ -93,6 +102,7 @@ public class PostServiceImpl implements PostService {
                 new PostPageResponseDto.Content(posts, page, size, totalCount);
 
         return new PostPageResponseDto(content, hasNext, nextPage);
+
 
     }
 

--- a/BookSpace/backend/src/main/resources/mappers/PostMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/PostMapper.xml
@@ -23,62 +23,89 @@
             )
     </insert>
 
-    <!--전체 게시글 개수 조회 <- 페이지네이션에 사용 -->
+    <!--전체 게시글 / 검색된 게시글 개수 조회 (isbn -> filter count) -->
     <select id="countAllPosts" resultType="int">
-        SELECT COUNT(*) FROM post
+        SELECT COUNT(*) FROM post p
+        JOIN book b ON b.book_id = p.book_id
+        <where>
+            <if test="isbn!=null and isbn!=''">
+                b.book_isbn = #{isbn}
+            </if>
+        </where>
     </select>
 
     <!-- 2. 전체 게시물 조회: 페이지네이션 적용-->
     <select id="selectAllPosts" resultType="postResponseDto">
         SELECT
-            p.post_id,
-            p.user_id,
-            p.book_id,
-            p.post_title,
-            p.post_content,
-            p.post_date,
-            p.post_view_cnt,
-            p.post_last_modified,
+        p.post_id,
+        p.user_id,
+        p.book_id,
+        p.post_title,
+        p.post_content,
+        p.post_date,
+        p.post_view_cnt,
+        p.post_last_modified,
 
-            -- 책 정보
-            b.book_title AS bookTitle,
-            b.book_author AS bookAuthor,
-            b.book_image_url AS bookImageUrl,
+        -- 책 정보
+        b.book_title AS bookTitle,
+        b.book_author AS bookAuthor,
+        b.book_image_url AS bookImageUrl,
 
-            -- 작성자 정보
-            u.user_nickname AS userNickname,
+        -- 작성자 정보
+        u.user_nickname AS userNickname,
 
-            -- 좋아요 개수
-            (SELECT COUNT(*)
-             FROM post_like pl
-                      JOIN user u2 ON pl.user_id = u2.user_id
-             WHERE pl.post_id = p.post_id
-               AND u2.user_status = 'active') AS likeCount,
+        -- 좋아요 개수
+        (SELECT COUNT(*)
+        FROM post_like pl
+        JOIN user u2 ON pl.user_id = u2.user_id
+        WHERE pl.post_id = p.post_id
+        AND u2.user_status = 'active') AS likeCount,
 
-            -- 댓글 개수
-            (SELECT COUNT(*)
-             FROM comment c
-             WHERE c.post_id = p.post_id) AS commentCount,
+        -- 댓글 개수: JOIN 집계 결과 사용
+        COALESCE(cc.comment_count, 0) AS commentCount,
 
-            -- 로그인 유저 좋아요 여부
-            CASE
-                WHEN #{userId} IS NULL THEN FALSE
-                WHEN EXISTS (
-                    SELECT 1
-                    FROM post_like pl
-                    WHERE pl.post_id = p.post_id
-                      AND pl.user_id = #{userId}
-                ) THEN TRUE
-                ELSE FALSE
-                END AS liked
+        -- 로그인 유저 좋아요 여부
+        CASE
+        WHEN #{userId} IS NULL THEN FALSE
+        WHEN EXISTS (
+        SELECT 1
+        FROM post_like pl
+        WHERE pl.post_id = p.post_id
+        AND pl.user_id = #{userId}
+        ) THEN TRUE
+        ELSE FALSE
+        END AS liked
+
         FROM post p
-                 JOIN book b ON p.book_id = b.book_id
-                 JOIN user u ON p.user_id = u.user_id
+        JOIN book b ON p.book_id = b.book_id
+        JOIN user u ON u.user_id = p.user_id
 
-        ORDER BY p.post_date DESC
+        -- 댓글 수 집계 JOIN (정렬/표시에 같이 사용)
+        LEFT JOIN (
+        SELECT post_id, COUNT(*) AS comment_count
+        FROM comment
+        GROUP BY post_id
+        ) cc ON cc.post_id = p.post_id
+
+        WHERE 1=1
+        <if test="isbn != null and isbn != ''">
+            AND b.book_isbn = #{isbn}
+        </if>
+
+        <choose>
+            <!-- sort = comments (댓글 많은 순)-->
+            <when test="sort == 'comment' or sort == 'comments'">
+                ORDER BY cc.comment_count DESC, p.post_date DESC, p.post_id DESC
+            </when>
+            <otherwise>
+                ORDER BY p.post_date DESC, p.post_id DESC
+            </otherwise>
+        </choose>
+
         LIMIT #{size}
         OFFSET #{offset}
     </select>
+
 
 
 


### PR DESCRIPTION
## PR Summary

* **Type**: edit
* **Scope**: BE(posts)
* **Issue**:  #79 / Refs #

---

## 작업 내용

### Frontend

* N/A

### Backend

1. **GET /posts 검색/필터 기능 확장 (기존 응답 포맷 유지)**

* `isbn` 쿼리 파라미터 추가

  * `isbn` 미포함: 전체 게시글 조회
  * `isbn` 포함: `book.book_isbn` 기준으로 `post` 필터링 & 검색
* `PostPageResponseDto` 응답 포맷 유지 -> FE CommunityView 무한 스크롤 로직 변경 없이 동작

2. **정렬 옵션 추가**

* `sort` 쿼리 파라미터 추가 (`latest`(default), `comments`)
* mapper에서 `ORDER BY` 분기 처리

  * `latest`: 최신순
  * `comments`: 댓글 많은 순 (동점 시 최신순/ID로 tie-break 적용)

3. **DB 스키마 제약 반영**

* `post` 테이블에 `isbn` 컬럼이 없으므로 `post -> book` 조인 후 `book_isbn = ?` 조건으로 필터링 

---

## API Spec

* `GET /posts?isbn={isbn13}&sort=latest`
* `GET /posts?isbn={isbn13}&sort=comments`

> `isbn` 생략 가능 / `sort` 생략 시 기본값 `latest`

---

## How to Test

1. `GET /posts?page=0&size=10` 호출
2. `GET /posts?page=0&size=10&isbn=9788936433598&sort=latest` 호출
3. `GET /posts?page=0&size=10&isbn=9788936433598&sort=comments` 호출
4. 페이지 증가(`page=1,2...`) 시 응답이 누락/중복 없이 이어지는지 확인
