### PR TITLE
[feat] 리뷰 수정/삭제 API 연동 및 UI 구성 (#110)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/dao/ReviewDao.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/dao/ReviewDao.java
@@ -37,5 +37,7 @@ public interface ReviewDao {
     // 8. 리뷰 개수 (by bookId)
     Integer countReviews(@Param("bookId") Long bookId);
 
+    // 9. 유저가 해당 도서에 리뷰를 작성했는지 확인 (1인 1리뷰 검증)
+    boolean existsByUserIdAndBookId(@Param("userId") long userId, @Param("bookId") long bookId);
 
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/service/ReviewServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/service/ReviewServiceImpl.java
@@ -1,10 +1,8 @@
 package com.bookspace.domain.review.service;
 
-import com.bookspace.domain.book.dao.BookDao;
 import com.bookspace.domain.book.service.BookService;
 import com.bookspace.domain.review.dto.ReviewRequestDto;
 import com.bookspace.domain.review.dao.ReviewDao;
-import com.bookspace.domain.review.dto.ReviewRequestDto;
 import com.bookspace.domain.review.dto.ReviewResponseDto;
 import com.bookspace.domain.review.vo.ReviewVo;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +37,7 @@ public class ReviewServiceImpl implements ReviewService {
         double rating = dto.getReviewRating();
 
         if (rating < 0.5 || rating > 5.0) {
-            throw new RuntimeException("Rating must be between 0.0 and 5.0.");
+            throw new RuntimeException("Rating must be between 0.5 and 5.0.");
         }
 
         // 2. 0.5 단위만 허용
@@ -49,6 +47,11 @@ public class ReviewServiceImpl implements ReviewService {
 
         // isbn 기반 DB 책 정보 확인 및 저장
         Long bookId = bookService.ensureBookExists(isbn);
+
+        // 1인 1리뷰 중복 방지
+        if (reviewDao.existsByUserIdAndBookId(loginUserId, bookId)) {
+            throw new RuntimeException("DUPLICATE_REVIEW");
+        }
 
         // 정상 등록 처리
         ReviewVo vo = new ReviewVo();
@@ -79,7 +82,19 @@ public class ReviewServiceImpl implements ReviewService {
             throw new AccessDeniedException("Access denied 본인의 리뷰만 수정할 수 있습니다.");
         }
 
-        // 3. 수정 실행
+        // 3. 평점 유효성 검사 (createReview와 동일 정책)
+        double rating = dto.getReviewRating();
+        // 1) rating 범위 유효성 검사
+        if (rating < 0.5 || rating > 5.0) {
+            throw new RuntimeException("Rating must be between 0.5 and 5.0.");
+        }
+
+        // 2) 0.5 단위만 허용
+        if (Math.abs(rating * 2 - Math.round(rating * 2)) > 1e-9) {
+            throw new RuntimeException("Rating must be in 0.5 increments.");
+        }
+
+        // 4. 수정 실행
         ReviewVo vo = new ReviewVo();
         vo.setReviewId(reviewId);
         vo.setReviewRating(dto.getReviewRating());

--- a/BookSpace/backend/src/main/resources/mappers/ReviewMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/ReviewMapper.xml
@@ -126,4 +126,13 @@
           AND u.user_status = 'active'
     </select>
 
+    <!--  1인 1리뷰 검증  -->
+    <select id="existsByUserIdAndBookId" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1
+            FROM review
+            WHERE user_id = #{userId}
+              AND book_id = #{bookId}
+        )
+    </select>
 </mapper>

--- a/BookSpace/frontend/src/components/bookDetail/BookSideCard.vue
+++ b/BookSpace/frontend/src/components/bookDetail/BookSideCard.vue
@@ -98,6 +98,6 @@ const fallbackCover =
 /** 평점 표시용 텍스트 */
 const averageRatingText = computed(() => {
   const r = Number(props.averageRating || 0);
-  return `${r.toFixed(1)} (${props.reviewCount})`;
+  return `${r.toFixed(1)}`;
 });
 </script>

--- a/BookSpace/frontend/src/components/review/MyReviewCard.vue
+++ b/BookSpace/frontend/src/components/review/MyReviewCard.vue
@@ -1,0 +1,95 @@
+<!-- 로그인 유저가 작성한 리뷰 카드 (수정, 삭제 버튼이 포함되어 있음) -->
+<template>
+  <div class="flex flex-col w-full p-5 border border-border rounded-xl bg-card shadow-sm">
+    <!-- 상단: 닉네임 / 날짜 / 평점 -->
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <p class="font-semibold text-foreground">
+          {{ review.nickname }}
+        </p>
+        <p class="text-sm text-muted-foreground">
+          {{ formattedDate }}
+        </p>
+      </div>
+
+      <div class="flex items-center gap-1">
+        <span class="relative -top-[2px] text-yellow-400 leading-none">★</span>
+        <span class="font-bold text-foreground">
+          {{ review.reviewRating }}
+        </span>
+      </div>
+    </div>
+
+    <!-- 리뷰 내용 -->
+    <p class="mt-4 text-sm text-foreground whitespace-pre-line">
+      {{ review.reviewContent }}
+    </p>
+
+    <!-- 수정/삭제 버튼 -->
+    <div class="mt-4 flex justify-end gap-2">
+        <button
+            type="button"
+            class="h-9 rounded-md px-4 text-sm font-semibold border border-input bg-background hover:bg-muted disabled:opacity-60"
+            :disabled="reviewStore.submitting"
+            @click="onDelete"
+        >
+        삭제
+        </button>
+
+        <button
+            type="button"
+            class="h-9 rounded-md px-4 text-sm font-semibold text-white bg-primary hover:bg-primary/90 disabled:opacity-60"
+            :disabled="reviewStore.submitting"
+            @click="$emit('edit')"
+        >
+        수정
+        </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useReviewStore } from "@/stores/reviewStore";
+
+const props = defineProps({
+  review: {
+    type: Object,
+    required: true,
+  },
+});
+
+const emit = defineEmits(["edit", "deleted"]);
+
+const reviewStore = useReviewStore();
+
+const formattedDate = computed(() => {
+  if (!props.review.reviewDate) return "";
+  const date = new Date(props.review.reviewDate);
+  return date.toLocaleDateString("ko-KR");
+});
+
+async function onDelete() {
+  const reviewId = props.review?.reviewId;
+  if (!reviewId) return;
+
+  const ok = confirm("리뷰를 삭제할까요?");
+  if (!ok) return;
+
+  try {
+    await reviewStore.deleteReview(reviewId);
+    alert("리뷰가 삭제되었습니다.");
+    emit("deleted");
+  } catch (e) {
+    const status = e?.response?.status;
+
+    if (status === 401) {
+      alert("로그인 후 이용 가능한 서비스입니다");
+    } else if (status === 403) {
+      alert("작성자만 수정/삭제할 수 있습니다");
+    } else {
+      alert(e?.response?.data?.message ?? "리뷰 삭제에 실패했습니다");
+    }
+  }
+}
+</script>

--- a/BookSpace/frontend/src/components/review/ReviewCreate.vue
+++ b/BookSpace/frontend/src/components/review/ReviewCreate.vue
@@ -43,9 +43,10 @@
         </button>
       </div>
 
-      <!-- 펼친 상태 -->
+      <!-- 펼친 상태 (create/edit 공용)-->
       <div v-else>
         <textarea
+          ref="expandedTextarea"
           v-model="content"
           :maxlength="maxLength"
           class="mt-3 w-full h-[160px] rounded-md border border-input bg-background p-4 text-sm outline-none focus-visible:ring-[3px] focus-visible:border-primary focus-visible:ring-ring/50 placeholder:text-muted-foreground resize-none"
@@ -57,31 +58,74 @@
           <span class="text-sm text-muted-foreground">{{ content.length }}/{{ maxLength }}</span>
         </div>
 
-        <button
-          type="button"
-          class="mt-6 h-10 w-full rounded-md bg-gray-400 text-base font-semibold text-white disabled:opacity-60"
-          :class="canSubmit ? 'bg-primary hover:bg-primary/90' : ''"
-          :disabled="props.isSubmitting"
-          @click="onSubmitExpanded"
-        >
-          {{ props.isSubmitting ? "등록 중..." : "등록하기" }}
-        </button>
+        <!-- edit 모드일 때 -->
+        <div class="mt-6 flex gap-2">
+          <button
+            v-if="isEditMode"
+            type="button"
+            class="h-10 w-1/3 rounded-md border border-input bg-background text-base font-semibold text-foreground disabled:opacity-60"
+            :disabled="reviewStore.submitting"
+            @click="onCancelEdit"
+          >
+            취소
+          </button>
+
+          <button
+            type="button"
+            class="h-10 w-full rounded-md bg-gray-400 text-base font-semibold text-white disabled:opacity-60"
+            :class="canSubmit ? 'bg-primary hover:bg-primary/90' : ''"
+            :disabled="reviewStore.submitting"
+            @click="onSubmitExpanded"
+          >
+            {{ reviewStore.submitting ? (isEditMode ? "수정 중..." : "등록 중...") : (isEditMode ? "수정하기" : "등록하기") }}
+          </button>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed, nextTick, ref } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useReviewStore } from "@/stores/reviewStore";
 import { useAuthStore } from "@/stores/authStore";
 import { useBookStore } from "@/stores/bookStore";
 import StarRating from "../ui/StarRating.vue";
 
 const authStore = useAuthStore();
+const reviewStore = useReviewStore();
 const bookStore = useBookStore();
+
 const isLoggedIn = computed(()=> authStore.isLoggedIn);
 
+// edit/create 공용으로 쓰기 위해 props 확장
+/**
+ * - mode: 'create' | 'edit'
+ * - initialRating / initialContent: edit 시작 시 폼에 채워 넣을 값
+ */
+const props = defineProps({
+  bookId: { type: Number, required: true },
+  isbn: { type: String, required: true },
+  maxLength: { type: Number, default: 300 },
+  mode: { type: String, default: "create" }, // 'create' | 'edit'
+  initialRating: { type: Number, default: 0 },
+  initialContent: { type: String, default: "" },
+  reviewId: { type: Number, default: null },
+
+});
+
+// ReviewSection과 통신 
+const emit = defineEmits(["saved", "cancel-edit"]);
+
+const isEditMode = computed(() => props.mode === "edit");
+
+const rating = ref(0);
+const content = ref("");
+const isExpanded = ref(false);
+
+const canSubmit = computed(() => rating.value > 0);
+
+// 비로그인 상태 : 입력/인터렉션 차단
 function blockIfNotLoggedIn(e) {
   if (isLoggedIn.value) return;
 
@@ -96,40 +140,54 @@ function blockIfNotLoggedIn(e) {
   alert("로그인 후 이용 가능한 서비스입니다");
 }
 
-
-const props = defineProps({
-  bookId: { type: Number, required: true },
-  isbn: { type: String, required: true },
-  maxLength: { type: Number, default: 300 },
-});
-
-const reviewStore = useReviewStore();
-
-const rating = ref(0);
-const content = ref("");
-const isExpanded = ref(false);
-
-const canSubmit = computed(() => rating.value > 0);
+const expandedTextarea = ref(null);
 
 const expand = async () => {
   if (isExpanded.value) return;
   isExpanded.value = true;
   await nextTick();
+
+  // 펼쳐진 textarea에 포커스
+  if (expandedTextarea.value) {
+    expandedTextarea.value.focus();
+  }
 };
 
 // textarea 클릭 핸들러
-const handleTextareaClick = (e) => {
+const handleTextareaClick = async (e) => {
   if (!isLoggedIn.value) {
     e.preventDefault();
     e.stopPropagation();
     alert("로그인 후 이용 가능한 서비스입니다");
-    e.target.blur(); // 포커스 제거
+    e.target.blur();
     return;
   }
-  expand();
+  await expand();
 };
 
-// 공통 제출 로직
+/**
+ * edit 모드 상태:
+ * - rating/content를 초기값으로 세팅
+ * - 폼은 바로 펼친 상태로 보여주기(수정 UX)
+ */
+watch(
+  () => [props.mode, props.reviewId, props.initialRating, props.initialContent],
+  async () => {
+    if (isEditMode.value) {
+      rating.value = props.initialRating ?? 0;
+      content.value = props.initialContent ?? "";
+      await expand();
+    } else {
+      // create 모드로 돌아오면 초기화 (원하면 유지해도 됨)
+      rating.value = 0;
+      content.value = "";
+      isExpanded.value = false;
+    }
+  },
+  { immediate: true }
+);
+
+// 공통 제출 로직 (creat/edit 분기)
 async function submitReview(payloadContent) {
   if (reviewStore.submitting) return;
 
@@ -140,6 +198,37 @@ async function submitReview(payloadContent) {
   }
 
   try {
+    // 리뷰 수정(PUT) - reviewId 필수
+    if (isEditMode.value) {
+      if (!props.reviewId) {
+        alert("수정할 리뷰 정보를 찾을 수 없습니다.");
+        return;
+      }
+
+      await reviewStore.updateReview(
+        props.reviewId,
+        {
+          reviewRating: rating.value,
+          reviewContent: payloadContent,
+        },
+        {
+          refreshBookId: props.bookId,
+          sort: "latest",
+        }
+      );
+
+      // 책 상세 정보 갱신 (평점, 리뷰 개수 업데이트)
+      // await bookStore.loadBookDetail(props.isbn);
+
+      alert("리뷰가 수정되었습니다.");
+
+      // 부모에게 “저장 완료” 알림 (부모가 edit 모드 종료 + 목록 재조회)
+      emit("saved");
+      return;
+    }
+
+
+    // 리뷰 등록 (POST)
     await reviewStore.createReview(
       {
         isbn: props.isbn,
@@ -155,21 +244,35 @@ async function submitReview(payloadContent) {
     // 책 상세 정보 갱신 (평점, 리뷰 개수 업데이트)
     await bookStore.loadBookDetail(props.isbn);
 
-    alert("리뷰가 등록되었습니다.");
-
     // 공통 초기화
     content.value = "";
     rating.value = 0;
+
+    // 부모에게 “저장 완료” 알림
+    emit("saved");
+
+    await nextTick();
+    
+    alert("리뷰가 등록되었습니다.");
+
+  
+
   } catch (e) {
     const status = e?.response?.status;
+    const msg = e?.response?.data?.message;
 
     if (status === 401) {
       alert("로그인 후 이용 가능한 서비스입니다");
     } else if (status === 403) {
       alert("작성자만 수정/삭제할 수 있습니다");
+    } else if (status === 400 && msg === "DUPLICATE_REVIEW") {
+      // 중복 리뷰인 경우
+      alert("이미 이 도서에 작성한 리뷰가 있습니다. 작성한 리뷰를 확인해주세요.");
+      emit("saved"); // 목록 갱신 트리거 (부모에서 fetch)
     } else {
-      alert(e?.response?.data?.message ?? "리뷰 등록에 실패했습니다");
+      alert(msg ?? (isEditMode.value ? "리뷰 수정에 실패했습니다" : "리뷰 등록에 실패했습니다"));
     }
+
   }
 }
 
@@ -183,8 +286,16 @@ async function onSubmitExpanded() {
   await submitReview(content.value.trim() || null);
 
   // 펼친 상태에서 등록 후 다시 접힘
-  isExpanded.value = false;
+  if (!isEditMode.value) {
+    isExpanded.value = false;
+  }
 }
+
+// 수정 취소
+function onCancelEdit() {
+  emit("cancel-edit");
+}
+
 </script>
 
 <style scoped>

--- a/BookSpace/frontend/src/components/review/ReviewList.vue
+++ b/BookSpace/frontend/src/components/review/ReviewList.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="space-y-4">
     <!-- 리뷰 없음 -->
-    <div v-if="!reviews?.length" class="rounded-xl border border-dashed border-border bg-card p-10 text-center text-sm text-muted-foreground">첫 번째 리뷰를 작성해보세요!</div>
+    <div 
+      v-if="!hasBookId || (!reviews?.length && !hasMyReview)" 
+      class="rounded-xl border border-dashed border-border bg-card p-10 text-center text-sm text-muted-foreground"
+    >
+      첫 번째 리뷰를 작성해보세요!
+    </div>
 
     <!-- 리뷰 목록 -->
     <ReviewCard v-else v-for="review in reviews" :key="review.reviewId ?? review.id" :review="review" />
@@ -15,6 +20,14 @@ defineProps({
   reviews: {
     type: Array,
     default: () => [],
+  },
+  hasBookId: {
+    type: Boolean,
+    default: false,
+  },
+  hasMyReview: {
+    type: Boolean,
+    default: false,
   },
 });
 </script>

--- a/BookSpace/frontend/src/components/review/ReviewSection.vue
+++ b/BookSpace/frontend/src/components/review/ReviewSection.vue
@@ -1,18 +1,45 @@
 <template>
   <div class="space-y-6">
-    <!-- 리뷰 작성 폼 -->
-    <ReviewCreate :book-id="bookId" :isbn="isbn"></ReviewCreate>
+    <!-- 리뷰 작성 폼 (내 리뷰가 없거나, 수정 모드일 때만 보임) -->
+    <ReviewCreate
+      v-if="!myReview || isEditing"
+      :book-id="bookId" 
+      :isbn="isbn"
+      :mode="isEditing ? 'edit' : 'create'"
+      :initial-rating="editInitial.rating"
+      :initial-content="editInitial.content"
+      :review-id="editInitial.reviewId"
+      @cancel-edit="handleCancelEdit"
+      @saved="handleSaved"
+      ></ReviewCreate>
 
-    <!-- 리뷰 목록 -->
-    <ReviewList :reviews="reviews"></ReviewList>
+    <!-- 내 리뷰가 있으면 상단에 리뷰 카드 고정 -->
+    <MyReviewCard
+      v-else
+      :review="myReview"
+      @edit="handleEdit"
+      @deleted="handleDeleted"
+    />
+
+    <!-- 리뷰 목록 (로그인 유저가 아닌 다른 사람들이 작성한 리뷰 목록) -->
+    <ReviewList 
+      :reviews="otherReviews" 
+      :has-book-id="!!bookId"
+      :has-my-review="!!myReview"
+    ></ReviewList>
   </div>
 </template>
 
 <script setup>
-import { computed, onMounted, watch } from "vue";
+import { ref, computed, onMounted, watch, nextTick } from "vue";
 import { useReviewStore } from "@/stores/reviewStore";
+import { useUserStore } from "@/stores/userStore";
+import { useAuthStore } from "@/stores/authStore";
+import { useBookStore } from "@/stores/bookStore";
+
 import ReviewCreate from "./ReviewCreate.vue";
 import ReviewList from "./ReviewList.vue";
+import MyReviewCard from "./MyReviewCard.vue";
 
 const props = defineProps({
   bookId: { type: Number, required: true },
@@ -20,23 +47,142 @@ const props = defineProps({
 });
 
 const reviewStore = useReviewStore();
+const userStore = useUserStore();
+const authStore = useAuthStore();
+const bookStore = useBookStore();
+
+const emit = defineEmits(["review-updated"]);
+
+const meLoading = ref(false);
+
+// 로그인 유저 id
+const me = computed(()=>userStore.me);
+const loginUserId = computed(() => me.value?.userId ?? null);
+
+// 전체 리뷰
 const reviews = computed(() => reviewStore.reviewsByBook);
 
+// 내 리뷰 찾기
+const myReview = computed(() => {
+  if (!loginUserId.value) return null;
+  return reviews.value.find((r) => String(r.userId) === String(loginUserId.value)) ?? null;
+});
+
+// 내 리뷰를 제외한 나머지 리뷰
+const otherReviews = computed(() => {
+  if (!myReview.value) return reviews.value;
+  return reviews.value.filter((r) => r.reviewId !== myReview.value.reviewId);
+});
+
+// 수정모드 상태
+const isEditing = ref(false);
+
+// 수정 시작 시 ReviewCreate에 주입할 초기값
+const editInitial = ref({
+  reviewId: null,
+  rating: 0,
+  content: "",
+});
+
+// 로그인 상태면 me를 먼저 확보
+const ensureMe = async () => {
+  if (!authStore.isLoggedIn) return;
+  if (me.value) return;
+
+  meLoading.value = true;
+  try {
+    await userStore.fetchMyInfo();
+  } catch (err) {
+    console.error("[REVIEW] failed to fetch my info", err);
+  } finally {
+    meLoading.value = false;
+  }
+};
+
+
+// 목록 로드
 const fetch = async () => {
+  // bookId 없으면 잔상 제거하고 종료
+  if (!props.bookId) {
+    reviewStore.reviewsByBook = [];
+    return;
+  }
+  reviewStore.reviewsByBook = [];
   // 일단 sort는 latest로 고정
   await reviewStore.fetchReviewsByBookId(props.bookId, "latest");
 };
 
-onMounted(fetch);
+onMounted(async () => {
+  // me를 먼저 확보한 뒤 리뷰 목록 로드
+  await ensureMe();
+  await fetch();
+});
 
-// bookId가 바뀌는 경우(다른 상세로 이동) 대비
+// bookId가 바뀌는 경우(다른 상세로 이동) 대비 + 수정모드 초깃화
 watch(
   () => props.bookId,
   async (newVal, oldVal) => {
     if (!newVal || newVal === oldVal) return;
+
+    reviewStore.reviewsByBook = [];
+
+    isEditing.value = false;
+    editInitial.value = { reviewId: null, rating: 0, content: "" };
+    
+    await ensureMe();
     await fetch();
   }
 );
+
+// 로그인 직후 상세 진입 대비
+watch(
+  () => authStore.isLoggedIn,
+  async (loggedIn) => {
+    if (!loggedIn) return;
+    await ensureMe();
+  }
+);
+
+// 수정 버튼 클릭 -> ReviewCreate를 edit 모드로 띄우기
+// 기존에 로그인 유저가 작성해둔 리뷰 평점 & 내용을 그대로
+function handleEdit() {
+  if (!myReview.value) return;
+
+  isEditing.value = true;
+  editInitial.value = {
+    reviewId: myReview.value.reviewId,
+    rating: myReview.value.reviewRating,
+    content: myReview.value.reviewContent ?? "",
+  };
+}
+
+// 수정 취소
+function handleCancelEdit() {
+  isEditing.value = false;
+  editInitial.value = { reviewId: null, rating: 0, content: "" };
+}
+
+// 작성/수정 완료 후
+async function handleSaved() {
+  isEditing.value = false;
+  editInitial.value = { reviewId: null, rating: 0, content: "" };
+  
+  await fetch(); // 리뷰 목록 갱신
+  await bookStore.loadBookDetail(props.isbn, { force: true }); // 평점/리뷰 개수 갱신
+  
+  emit("review-updated");
+}
+
+// 삭제 완료 후
+async function handleDeleted() {
+  await fetch(); // 리뷰 목록 갱신
+  await bookStore.loadBookDetail(props.isbn); // 평점/리뷰 개수 갱신
+
+  emit("review-updated");
+
+  isEditing.value = false;
+  editInitial.value = { reviewId: null, rating: 0, content: "" };
+}
 
 </script>
 

--- a/BookSpace/frontend/src/views/BookDetailView.vue
+++ b/BookSpace/frontend/src/views/BookDetailView.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="mx-auto max-w-6xl px-4 py-6">
 
-    <div v-if="loadingDetail" class="py-10 text-sm text-muted-foreground">
+    <div v-if="loadingDetail && !book" class="py-10 text-sm text-muted-foreground">
       상세 정보를 불러오는 중...
     </div>
 
@@ -46,10 +46,14 @@
         <BookDetailInfo :book="book" />
 
         <!-- 리뷰 / 게시글 탭 -->
-        <ReviewPostTabs v-model="activeTab" :review-count="reviewCount" :post-count="postCount">
+        <ReviewPostTabs v-model="activeTab" :key="book.bookId" :review-count="reviewCount" :post-count="postCount">
           <!-- ReviewSection -->
           <template #review>
-            <ReviewSection :book-id="book.bookId" :isbn="book.isbn"/>
+            <ReviewSection 
+              :key="book.bookId" 
+              :book-id="book.bookId" 
+              :isbn="book.isbn"
+              @review-updated="load"/>
           </template>
 
           <!-- PostSection -->
@@ -106,17 +110,17 @@ const isWished = computed(() => {
   if (!book.value) return false;
   return wishStore.isWished(book.value.isbn);
 });
-const averageRating = computed(() => bookStore.bookDetail?.averageRating ?? 0.0);
-const reviewCount = computed(() => bookStore.bookDetail?.reviewCount ?? 0);
-const postCount = computed(() => bookStore.bookDetail?.postCount ?? 0);
+const averageRating = computed(() => book.value?.averageRating ?? 0.0);
+const reviewCount = computed(() => book.value?.reviewCount ?? 0);
+const postCount = computed(() => book.value?.postCount ?? 0);
 
 const loadingDetail = computed(() => bookStore.loadingDetail);
 const detailError = computed(() => bookStore.detailError);
 
-const load = () => {
+const load = async() => {
   const isbn = route.params.isbn;
   if (!isbn) return;
-  bookStore.loadBookDetail(isbn);
+  await bookStore.loadBookDetail(isbn);
 };
 
 onMounted(load);


### PR DESCRIPTION
## 작업 개요
- 도서 상세 화면에서 사용할 리뷰 수정 / 삭제 기능 구현
- 리뷰 작성 정책(1인 1리뷰)을 기준으로 API 연동과 UI 흐름을 설계하고,  
리뷰 작성 후 도서 정보(평점/리뷰 개수)가 실시간으로 반영되도록 구성


## 주요 구현 기능

### 1. 리뷰 수정 / 삭제 기능 구현
- 리뷰 수정 / 삭제 API 연동
- 수정·삭제 성공 시:
  - 리뷰 목록 즉시 갱신
  - 평점 및 리뷰 개수 함께 동기화
- 작성자 권한 검증 및 예외 처리 반영


### 2. 1인 1리뷰 정책 적용
- 사용자당 하나의 리뷰만 작성 가능하도록 정책 적용
  - 한 명의 사용자에 의한 평점 중복 반영으로 인한 평점 왜곡 문제 방지
  - 리뷰 정보 신뢰도 저하 방지 
- 사용자가 작성한 리뷰는:
  - 리뷰 목록 **최상단에 고정 노출**
  - **작성자 본인에게만 수정 / 삭제 버튼 노출**
- 타 사용자의 리뷰에는 수정 / 삭제 UI가 노출되지 않음
- **이미 본인이 작성한 리뷰가 있는 경우**:
  - `ReviewCreate`(리뷰 작성 폼) 비노출
  - 중복 리뷰 작성 방지


### 3. 리뷰 작성 UX 설계
- 리뷰 입력 영역은 기본적으로 접힌 상태로 제공
- 접힌 상태에서 클릭 시 textarea 자동 포커스 기능 추가
