### PR TITLE
[BE_Edit] Profile(Mypage) 관련 wish, review, post api 엔드포인트 및  응답 수정(#120)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/book/controller/BookController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/book/controller/BookController.java
@@ -94,4 +94,6 @@ public class BookController {
     public BookDetailResponseDto getBookDetail(@PathVariable String isbn) {
         return bookService.getBookDetail(isbn);
     }
+
+
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
@@ -93,8 +93,9 @@ public class PostController {
     }
 
     // 7. userId로 조회
-    @GetMapping(params = "userId")
-    public ResponseEntity<List<PostResponseDto>> getPostsByUserId(long userId) {
+    @GetMapping("/me")
+    public ResponseEntity<List<PostResponseDto>> getMyPosts(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
         return ResponseEntity.ok(postService.getPostsByUserId(userId));
     }
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/dao/PostDao.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/dao/PostDao.java
@@ -38,8 +38,8 @@ public interface PostDao {
     // 7. 게시글 조회 (by bookId)
     List<PostVo> selectPostsByBookId(@Param("bookId") long bookId);
 
-    // 8. 게시글 조회 (by userId)
-    List<PostVo> selectPostsByUserId(@Param("userId") long userId);
+    // 8. 게시글 조회 (my)
+    List<PostResponseDto> selectPostsByUserId(@Param("userId") long userId);
 
     // 9. 게시글 조회 (by keyword)
     List<PostVo> selectPostsByKeyword(@Param("keyword") String keyword);

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
@@ -203,10 +203,8 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public List<PostResponseDto> getPostsByUserId(long userId) {
-        List<PostVo> postVoList = postDao.selectPostsByUserId(userId);
-        return postVoList.stream()
-                .map(this::convertToResponseDto)
-                .toList();
+        List<PostResponseDto> results = postDao.selectPostsByUserId(userId);
+        return results;
     }
 
     @Override

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/controller/ReviewController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/controller/ReviewController.java
@@ -63,10 +63,10 @@ public class ReviewController {
         return ResponseEntity.ok(reviewService.getReviewById(reviewId));
     }
 
-    // 5. 리뷰 조회 (by userId)
-    @GetMapping(params = "userId")
-    // /reviews?userId=3
-    public ResponseEntity<List<ReviewResponseDto>> getReviewsByUserId(@RequestParam long userId) {
+    // 5. 리뷰 조회 (by user)
+    @GetMapping("/me")
+    public ResponseEntity<List<ReviewResponseDto>> getMyReviews(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
         return ResponseEntity.ok(reviewService.getReviewsByUserId(userId));
     }
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/dao/ReviewDao.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/dao/ReviewDao.java
@@ -1,5 +1,6 @@
 package com.bookspace.domain.review.dao;
 
+import com.bookspace.domain.review.dto.ReviewResponseDto;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.bookspace.domain.review.vo.ReviewVo;
@@ -23,7 +24,7 @@ public interface ReviewDao {
     int deleteReview(@Param("reviewId") Long reviewId);
 
     // 5. 리뷰 조회 (by userId)
-    List<ReviewVo> selectReviewsByUserId(@Param("userId") Long userId);
+    List<ReviewResponseDto> selectReviewsByUserId(@Param("userId") Long userId);
 
     // 6. 리뷰 조회 (by bookId) (정렬 포함)
     List<ReviewVo> selectReviewsByBookId(

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/dto/ReviewResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/dto/ReviewResponseDto.java
@@ -9,6 +9,12 @@ public class ReviewResponseDto {
 
     private long reviewId;
     private long bookId;
+
+    private String bookIsbn;
+    private String bookTitle;
+    private String bookImageUrl;
+    private String bookAuthor;
+
     private long userId;
     private String nickname; // 사용자 닉네임 (JOIN 해서 가져옴)
     private Double reviewRating;

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/review/service/ReviewServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/review/service/ReviewServiceImpl.java
@@ -133,10 +133,8 @@ public class ReviewServiceImpl implements ReviewService {
     // 5. 특정 사용자의 리뷰 목록 조회 (by userId)
     @Override
     public List<ReviewResponseDto> getReviewsByUserId(long userId) {
-        List<ReviewVo> reviewVoList = reviewDao.selectReviewsByUserId(userId);
-        return reviewVoList.stream()
-                .map(this::convertToResponseDto)
-                .toList();
+        List<ReviewResponseDto> results = reviewDao.selectReviewsByUserId(userId);
+        return results;
     }
 
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/controller/UserController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,8 +46,13 @@ public class UserController {
 
 
     // 3. 회원 정보 조회 (by userId)
-    @GetMapping("/{userId}")
-    public ResponseEntity<UserResponseDto> getUserById(@PathVariable long userId) {
+    @GetMapping("/me")
+    public ResponseEntity<UserResponseDto> getMe(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new AccessDeniedException("Unauthorized");
+        }
+
+        long userId = userDetails.getUserId();
         UserResponseDto response = userService.getUserById(userId);
         return ResponseEntity.ok(response);
     }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/wish/controller/WishController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/wish/controller/WishController.java
@@ -67,7 +67,7 @@ public class WishController {
     // 3. 찜한 책 목록 조회: GET /wishes
     // 타인의 찜 목록은 못 보는게 일반적
     // 굳이 url에 userId를 표기할 필요가 X
-    @GetMapping
+    @GetMapping("/me")
     public ResponseEntity<List<WishResponseDto>> getMyWishes() {
         long userId = getCurrentUserId();
         List<WishResponseDto> wishes = wishService.getWishesByUserId(userId);

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/wish/dto/WishResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/wish/dto/WishResponseDto.java
@@ -16,5 +16,6 @@ public class WishResponseDto {
     // 찜 목록 조회 시 필요한 book 정보
     private String bookTitle;
     private String bookAuthor;
+    private String bookIsbn;
     private String bookImageUrl;
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
@@ -74,16 +74,17 @@ public class SecurityConfig {
                                 "/",
                                 "/login",
                                 "/join",
-                                "/users/**",
                                 "/auth/**",
                                 "/books/**"
                         ).permitAll() // 인증 없이 가능
+                        .requestMatchers("/users/me/**").authenticated()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/posts/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/reviews/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/reviews").permitAll()
                         .requestMatchers(HttpMethod.POST, "/reviews/**").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/reviews/**").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/reviews/**").authenticated()
+                        .requestMatchers("/wishes/me", "/posts/me", "/reviews/me").authenticated()
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated() // 나머지 요청은 jwt가 필요함
                 )

--- a/BookSpace/backend/src/main/resources/mappers/PostMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/PostMapper.xml
@@ -226,19 +226,31 @@
     <!-- 8. 특정 사용자에 대한 게시글 조회-->
     <select id="selectPostsByUserId"
             parameterType="long"
-            resultType="postVo">
+            resultType="postResponseDto">
         SELECT
-            post_id,
-            user_id,
-            book_id,
-            post_title,
-            post_content,
-            post_date,
-            post_view_cnt,
-            post_last_modified
-        FROM post
-        WHERE user_id = #{userId}
-        ORDER BY post_date DESC
+            p.post_id,
+            p.user_id,
+            p.book_id,
+            p.post_title,
+            p.post_content,
+            p.post_date,
+            p.post_view_cnt,
+            p.post_last_modified,
+            b.book_title      AS bookTitle,
+            b.book_author     AS bookAuthor,
+            b.book_image_url  AS bookImageUrl,
+            u.user_nickname   AS userNickName, (SELECT COUNT(*) FROM post_like pl WHERE pl.post_id = p.post_id) AS likeCount,
+
+            (SELECT COUNT(*) FROM comment c WHERE c.post_id = p.post_id) AS commentCount,
+
+            (SELECT COUNT(*) FROM post_like pl
+             WHERE pl.post_id = p.post_id AND pl.user_id = #{userId}) > 0 AS liked
+
+        FROM post p
+                 JOIN book b ON p.book_id = b.book_id
+                 JOIN user u ON p.user_id = u.user_id
+        WHERE p.user_id = #{userId}
+        ORDER BY p.post_date DESC
     </select>
 
     <!-- 9. 키워드로 게시글 조회 (제목 + 내용) -->

--- a/BookSpace/backend/src/main/resources/mappers/ReviewMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/ReviewMapper.xml
@@ -58,9 +58,9 @@
         WHERE review_id = #{reviewId}
     </delete>
 
-    <!-- 리뷰 조회 (by userId) -->
+    <!-- 리뷰 조회 (by user) -->
     <select id="selectReviewsByUserId"
-            resultType="com.bookspace.domain.review.vo.ReviewVo">
+            resultType="com.bookspace.domain.review.dto.ReviewResponseDto">
         SELECT
         r.review_id,
         r.book_id,
@@ -69,12 +69,21 @@
         r.review_content,
         r.review_date,
         r.review_last_modified,
-        u.user_nickname AS nickname
+
+        u.user_nickname AS nickname,
+
+        b.book_isbn    AS bookIsbn,
+        b.book_title   AS bookTitle,
+        b.book_author AS bookAuthor,
+        b.book_image_url AS bookImageUrl
+
         FROM review r
         JOIN user u ON r.user_id = u.user_id
+        JOIN book b ON r.book_id = b.book_id
         WHERE r.user_id = #{userId}
         ORDER BY r.review_date DESC
     </select>
+
 
     <!-- 리뷰 조회 (by bookId) -->
     <select id="selectReviewsByBookId"

--- a/BookSpace/backend/src/main/resources/mappers/WishMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/WishMapper.xml
@@ -37,6 +37,7 @@
             w.wish_date,
             b.book_title,
             b.book_author,
+            b.book_isbn,
             b.book_image_url
         FROM wish w
         JOIN book b ON w.book_id = b.book_id


### PR DESCRIPTION
## PR Summary

- **Type**: Edit
- **Scope**: BE(mypage, wish, review, post)
- **Issue**: #120 

---

## Changes
- MyPage 조회용 엔드포인트 **`/wishes/me`, `/reviews/me`, `/posts/me`** 응답/조회 로직 수정
- 찜(Wish), 리뷰(Review) 응답 값에 **`isbn` 필드 추가**
- Review ResponseDto에 **`bookTitle`, `bookAuthor`, `isbn`** 필드 추가하여 마이페이지/리뷰 리스트에서 필요한 도서 메타데이터 제공

---

## 3) Changes

### Frontend

- N/A

### Backend

- **EndPoints**
    - `GET /wishes/me` : 로그인 유저의 찜 목록 조회 (도서 메타 + isbn 포함)
    - `GET /reviews/me` : 로그인 유저의 리뷰 목록 조회 (도서 메타 + isbn 포함)
    - `GET /posts/me` : 로그인 유저의 게시글 목록 조회 (기존 마이페이지 연동을 위해 정리/수정)
- **Contract Changes (req/res)**
    - Wish 응답: `bookIsbn`(또는 `isbn`) 필드 추가 *(FE 상세 이동 지원)*
    - Review 응답: `isbn` + `bookTitle` + `bookAuthor` 필드 보강 *(VO 확장 기반)*
- **Business Logic**
    - “me” 계열은 `@AuthenticationPrincipal` 기반 로그인 유저 식별로 조회
- **DB / Mybatis**
    - Wish/Review 조회 쿼리에서 `book.isbn` 조인/조회 추가
    - Review VO 매핑 컬럼 확장(제목/저자/isbn)
- **Logs / Monitoring**
    - N/A

---

## How to Test
1. 토큰값을 포함하여 아래 API 호출
    - `GET /wishes/me`
    - `GET /reviews/me`
    - `GET /posts/me`
3. 응답에 `isbn` 필드가 포함되는지 확인
