### PR TITLE
[feat] PostInBookDetail API 연동 (#111)

### DIFF
--- a/BookSpace/frontend/src/components/postInBookDetail/PostCardInBookDetail.vue
+++ b/BookSpace/frontend/src/components/postInBookDetail/PostCardInBookDetail.vue
@@ -1,0 +1,61 @@
+<template>
+  <div
+    class="w-full rounded-xl border border-border bg-card p-5 shadow-sm transition hover:shadow-md cursor-pointer"
+    :data-post-id="post.postId"
+    @click="goToPostDetail"
+  >
+    <!-- 제목 -->
+    <h2 class="text-lg font-semibold text-foreground">
+      {{ post.postTitle }}
+    </h2>
+
+    <!-- 작성자 + 작성일 -->
+    <p class="mt-1 text-sm text-muted-foreground">
+      {{ post.userNickName }}
+      <span class="mx-1">·</span>
+      {{ formattedDate }}
+    </p>
+
+    <!-- 내용 -->
+    <p class="mt-4 text-sm text-foreground/90 line-clamp-2 whitespace-pre-line">
+      {{ post.postContent }}
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+
+const props = defineProps({
+  post: {
+    type: Object,
+    required: true,
+  },
+});
+
+const router = useRouter();
+
+// 작성일자 포맷
+const formattedDate = computed(() => {
+  if (!props.post.postDate) return "";
+  const date = new Date(props.post.postDate);
+  return date.toLocaleDateString("ko-KR");
+});
+
+const goToPostDetail = () => {
+  router.push({
+    name: "postDetail",
+    params: { postId: props.post.postId },
+  });
+};
+</script>
+
+<style scoped>
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+</style>

--- a/BookSpace/frontend/src/components/postInBookDetail/PostCreateModal.vue
+++ b/BookSpace/frontend/src/components/postInBookDetail/PostCreateModal.vue
@@ -9,7 +9,7 @@
       <div class="relative z-10 w-[560px] max-w-[92vw] rounded-xl bg-background border shadow-xl" @click.stop>
         <!-- header -->
         <div class="flex items-center justify-between px-6 py-4">
-          <h3 class="text-lg font-semibold text-foreground">토론 게시글 작성</h3>
+          <h3 class="text-lg font-semibold text-foreground">게시글 작성</h3>
 
           <button type="button" class="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-muted transition" aria-label="닫기" @click="close">✕</button>
         </div>
@@ -39,7 +39,7 @@
 
           <button
             type="button"
-            class="w-full h-11 rounded-md font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50 bg-muted-foreground/60"
+            class="h-10 w-full rounded-md bg-gray-400 text-base font-semibold text-white disabled:opacity-60"
             :class="canSubmit ? 'bg-primary hover:bg-primary/90' : ''"
             :disabled="!canSubmit"
             @click="submit"
@@ -62,11 +62,17 @@ const content = ref("");
 
 const canSubmit = computed(() => title.value.length > 0 && content.value.length > 0);
 
-const close = () => emit("close");
+const close = () => {
+  title.value = "";
+  content.value = "";
+  emit("close");
+};
 
 const submit = () => {
   if (!canSubmit.value) return;
   emit("submit", { title: title.value, content: content.value });
+  title.value = "";
+  content.value = "";
 };
 
 // 모달 뜰 때 키보드 이벤트(ESC) 잘 먹게 포커스

--- a/BookSpace/frontend/src/components/postInBookDetail/PostList.vue
+++ b/BookSpace/frontend/src/components/postInBookDetail/PostList.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="space-y-4">
+    <!-- 로딩(초기) -->
+    <div
+      v-if="loading && !posts.length"
+      class="rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground"
+    >
+      게시글을 불러오는 중...
+    </div>
+
+    <!-- 에러 -->
+    <div
+      v-else-if="error"
+      class="rounded-xl border border-destructive/30 bg-card p-6 text-sm"
+    >
+      <p class="font-medium text-foreground">게시글을 불러오지 못했어요.</p>
+      <p class="mt-1 text-muted-foreground">잠시 후 다시 시도해주세요.</p>
+
+      <button
+        v-if="showRetry"
+        type="button"
+        class="mt-4 h-9 rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+        @click="$emit('retry')"
+      >
+        다시 시도
+      </button>
+    </div>
+
+    <!-- 게시글이 없을 때 -->
+    <div
+      v-else-if="!posts.length"
+      class="flex min-h-[160px] flex-col items-center justify-center rounded-xl border border-dashed border-border bg-card p-6 text-sm text-muted-foreground"
+    >
+      아직 게시글이 없어요.
+      <span class="mt-1">첫 번째 게시글을 작성해보세요!</span>
+    </div>
+
+    <!-- list -->
+    <div v-else class="space-y-4">
+      <PostCardInBookDetail
+        v-for="post in posts"
+        :key="post.postId ?? post.id"
+        :post="post"
+      />
+    </div>
+
+    <!-- 더보기 -->
+    <div v-if="posts.length" class="pt-2">
+      <button
+        v-if="hasNext"
+        type="button"
+        class="w-full h-11 rounded-md border border-border bg-background text-sm font-semibold hover:bg-muted transition disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="isFetchingNext"
+        @click="$emit('load-more')"
+      >
+        {{ isFetchingNext ? "불러오는 중..." : "더 보기" }}
+      </button>
+
+      <p v-else class="py-3 text-center text-xs text-muted-foreground">
+        마지막 게시글까지 확인했어요.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import PostCardInBookDetail from "./PostCardInBookDetail.vue";
+
+defineProps({
+  posts: { type: Array, default: () => [] },
+  loading: { type: Boolean, default: false },
+  error: { type: Boolean, default: false },
+  showRetry: { type: Boolean, default: true },
+
+  // 더보기 관련
+  hasNext: { type: Boolean, default: false },
+  isFetchingNext: { type: Boolean, default: false },
+});
+
+defineEmits(["retry", "load-more"]);
+</script>

--- a/BookSpace/frontend/src/components/postInBookDetail/PostSection.vue
+++ b/BookSpace/frontend/src/components/postInBookDetail/PostSection.vue
@@ -2,39 +2,139 @@
   <section class="space-y-6">
     <!-- 헤더 -->
     <div class="flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-foreground">토론 게시글</h2>
+      <h2 class="text-2xl font-semibold text-foreground">게시글</h2>
 
-      <!-- 스샷 느낌: + 아이콘 + 게시글 작성 -->
-      <Button class="h-9 px-4 text-white font-extrabold inline-flex items-center gap-2" @click="openCreateModal">
+      <button
+        type="button"
+        class="h-9 px-4 rounded-md bg-primary text-primary-foreground font-semibold inline-flex items-center gap-2 hover:bg-primary/90"
+        @click.stop="openCreateModal"
+      >
         <PlusIcon class="w-4 h-4" />
         게시글 작성
-      </Button>
+      </button>
     </div>
 
     <!-- 리스트 -->
-    <PostList />
+    <PostList
+      :posts="flatPosts"
+      :loading="postsQuery.isLoading.value"
+      :error="postsQuery.isError.value"
+      :has-next="postsQuery.hasNextPage.value"
+      :is-fetching-next="postsQuery.isFetchingNextPage.value"
+      @retry="refetch"
+      @load-more="fetchNextPage"
+    />
 
     <!-- 작성 모달 -->
-    <PostCreateModal v-if="isModalOpen" @close="isModalOpen = false" @created="handleCreated" />
+    <PostCreateModal
+      v-if="isModalOpen"
+      @close="isModalOpen = false"
+      @submit="handleSubmit"
+    />
   </section>
 </template>
 
 <script setup>
-import { ref } from "vue";
-import Button from "@/components/ui/Button.vue";
+import { computed, ref } from "vue";
 import { PlusIcon } from "lucide-vue-next";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/vue-query";
 
+import PostList from "./PostList.vue";
 import PostCreateModal from "./PostCreateModal.vue";
 
-const isModalOpen = ref(false);
+import { fetchPosts, createPostApi } from "@/api/postApi";
+import { useAuthStore } from "@/stores/authStore";
+import { useBookStore } from "@/stores/bookStore";
 
-const openCreateModal = () => {
-  isCreateOpen.value = true;
+const emit = defineEmits(["post-updated"]);
+
+const props = defineProps({
+  isbn: { type: String, required: true },
+  bookId: { type: Number, required: false },
+});
+
+const bookStore = useBookStore();
+const authStore = useAuthStore();
+const queryClient = useQueryClient();
+
+const isModalOpen = ref(false);
+const sort = ref("latest");
+
+// 도서별 캐시 분리(섞임 방지)
+const queryKey = computed(() => ["posts", props.isbn, sort.value]);
+
+const postsQuery = useInfiniteQuery({
+  queryKey,
+  queryFn: ({ pageParam = 0 }) =>
+    fetchPosts({ pageParam, isbn: props.isbn, sort: sort.value }),
+  getNextPageParam: (lastPage) =>
+    lastPage?.hasNext ? lastPage.nextPage : undefined,
+  initialPageParam: 0,
+  enabled: computed(() => !!props.isbn),
+});
+
+const flatPosts = computed(() => {
+  const pages = postsQuery.data.value?.pages ?? [];
+  return pages.flatMap((p) => p.posts ?? []);
+});
+
+const fetchNextPage = async () => {
+  if (!postsQuery.hasNextPage.value) return;
+  await postsQuery.fetchNextPage();
 };
 
-// (선택) 작성 완료 후 모달 닫기 + 리스트 갱신 트리거 연결용
-const handleCreated = () => {
-  isCreateOpen.value = false;
-  // 여기서 refetch() 하거나, 상위에 emit해서 다시 불러오게 연결 가능
+const refetch = async () => {
+  await postsQuery.refetch();
+};
+
+const openCreateModal = () => {
+  if (!authStore.isLoggedIn) {
+    alert("로그인 후 이용 가능한 서비스입니다");
+    return;
+  }
+  isModalOpen.value = true;
+};
+
+const handleSubmit = async ({ title, content }) => {
+  if (!authStore.isLoggedIn) {
+    alert("로그인 후 이용 가능한 서비스입니다");
+    return;
+  }
+
+  try {
+    // 모달에서 게시글 등록 시 isbn/bookId 함께 전달
+    await createPostApi({
+      isbn: props.isbn,
+      bookId: props.bookId,
+      postTitle: title,
+      postContent: content,
+    });
+  } catch (e) {
+    const status = e?.response?.status;
+    if (status === 401) alert("로그인 후 이용 가능한 서비스입니다");
+    else alert(e?.response?.data?.message ?? "게시글 등록에 실패했습니다");
+    return;
+  }
+
+  
+  alert("게시글이 등록되었습니다.");
+  isModalOpen.value = false;
+
+  // 게시글 목록 갱신
+  try {
+    await queryClient.invalidateQueries({ queryKey: queryKey.value });
+  } catch (e) {
+    console.warn("[invalidateQueries failed]", e);
+  }
+
+  // BookSideCard postCount 갱신
+  try {
+    await bookStore.loadBookDetail(props.isbn, { force: true });
+  } catch (e) {
+    console.warn("[loadBookDetail failed]", e);
+  }
+
+  // 부모에게 전달
+  emit("post-updated");
 };
 </script>

--- a/BookSpace/frontend/src/views/BookDetailView.vue
+++ b/BookSpace/frontend/src/views/BookDetailView.vue
@@ -58,7 +58,11 @@
 
           <!-- PostSection -->
           <template #post>
-            <PostSection />
+            <PostSection 
+              :isbn="book.isbn" 
+              :book-id="book.bookId"
+              @post-updated="load"
+            />
           </template>
         </ReviewPostTabs>
       </section>


### PR DESCRIPTION
## 주요 작업 내용

### 1. 도서 상세 페이지 내 게시글 목록 표시
- 도서 상세 화면의 **커뮤니티 탭(PostSection)** 에서 해당 도서(`isbn / bookId`)에 작성된 게시글만 조회되도록 구현
- 기존 CommunityView에서 사용하던 Post 도메인 API/구조 재사용
- 게시글 카드 UI를 도서 상세 전용(`PostCardInBookDetail`)으로 분리하여 적용


### 2. 게시글 작성 모달(PostCreateModal) 연동
- 도서 상세 페이지 내에서 게시글 작성 가능하도록 모달 UI 구현
- 게시글 작성 시 도서 식별자(`isbn / bookId`)를 함께 전달하여 저장


### 3. 게시글 작성 후 실시간 UI 갱신
- 게시글 작성 성공 시:
  - 게시글 목록 즉시 갱신
  - 도서 상세 정보 재조회를 통해 **BookSideCard의 postCount 즉시 반영**

