### PR TITLE
feat: 찜/리뷰 즉시 반영 및 로그인 요구 처리 구조 개선

### DIFF
--- a/BookSpace/frontend/src/components/review/ReviewDetailModal.vue
+++ b/BookSpace/frontend/src/components/review/ReviewDetailModal.vue
@@ -19,23 +19,80 @@
         <p class="text-xs text-muted-foreground">
           {{ formattedDate }}
         </p>
-        <div class="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-amber-700">
+        <div
+          class="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-amber-700"
+        >
           <span class="text-base leading-none">★</span>
           <span class="text-base font-semibold">
-            {{ review.rating ?? review.reviewRating ?? 0 }}
+            {{ displayRating }}
           </span>
         </div>
       </div>
     </div>
 
-    <div class="rounded-xl border border-border bg-card p-4 text-sm whitespace-pre-line text-foreground min-h-[120px]">
+    <div
+      v-if="isEditing"
+      class="space-y-3 rounded-xl border border-border bg-card p-4 text-sm text-foreground"
+    >
+      <div class="flex flex-col gap-2">
+        <span class="text-sm font-medium text-foreground">평점</span>
+        <StarRating v-model="draftRating" :step="0.5" :showValue="true" />
+      </div>
+      <textarea
+        v-model="draftContent"
+        rows="5"
+        class="w-full rounded-lg border border-input bg-background p-3 text-sm"
+        placeholder="리뷰 내용을 입력하세요"
+      />
+    </div>
+    <div
+      v-else
+      class="rounded-xl border border-border bg-card p-4 text-sm whitespace-pre-line text-foreground min-h-[120px]"
+    >
       {{ review.reviewContent || "내용 없음" }}
+    </div>
+
+    <div class="flex justify-end gap-2 pt-2">
+      <template v-if="isEditing">
+        <button
+          type="button"
+          class="h-9 rounded-md px-4 text-sm font-semibold border border-input bg-background hover:bg-muted"
+          @click="cancelEdit"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          class="h-9 rounded-md px-4 text-sm font-semibold text-white bg-primary hover:bg-primary/90"
+          @click="submitEdit"
+        >
+          저장
+        </button>
+      </template>
+      <template v-else>
+        <button
+          type="button"
+          class="h-9 rounded-md px-4 text-sm font-semibold border border-input bg-background hover:bg-muted"
+          @click="$emit('delete', review)"
+        >
+          삭제
+        </button>
+        <button
+          type="button"
+          class="h-9 rounded-md px-4 text-sm font-semibold text-white bg-primary hover:bg-primary/90"
+          @click="startEdit"
+        >
+          수정
+        </button>
+      </template>
     </div>
   </div>
 </template>
 
 <script setup>
+import { computed, ref, watch } from "vue";
 import { useFormattedDate } from "@/composables/useFormattedDate";
+import StarRating from "@/components/ui/StarRating.vue";
 
 const props = defineProps({
   review: {
@@ -44,7 +101,46 @@ const props = defineProps({
   },
 });
 
+const emit = defineEmits(["update", "delete"]);
+
 const formattedDate = useFormattedDate(props.review.reviewDate, {
   dateStyle: "medium",
 });
+
+const isEditing = ref(false);
+const draftRating = ref(props.review.rating ?? props.review.reviewRating ?? 0);
+const draftContent = ref(props.review.reviewContent ?? "");
+
+const displayRating = computed(
+  () => props.review.rating ?? props.review.reviewRating ?? 0
+);
+
+watch(
+  () => props.review,
+  (next) => {
+    if (!next) return;
+    draftRating.value = next.rating ?? next.reviewRating ?? 0;
+    draftContent.value = next.reviewContent ?? "";
+    isEditing.value = false;
+  }
+);
+
+const startEdit = () => {
+  isEditing.value = true;
+};
+
+const cancelEdit = () => {
+  isEditing.value = false;
+  draftRating.value = props.review.rating ?? props.review.reviewRating ?? 0;
+  draftContent.value = props.review.reviewContent ?? "";
+};
+
+const submitEdit = () => {
+  const rating = Number(draftRating.value);
+  emit("update", {
+    reviewId: props.review.reviewId,
+    rating: Number.isNaN(rating) ? 0 : rating,
+    content: draftContent.value ?? "",
+  });
+};
 </script>

--- a/BookSpace/frontend/src/composables/profile/useMyReviews.js
+++ b/BookSpace/frontend/src/composables/profile/useMyReviews.js
@@ -1,13 +1,19 @@
 import { computed } from "vue";
-import { useQuery } from "@tanstack/vue-query";
-import { fetchMyReviewsApi } from "@/api/reviewApi";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/vue-query";
+import {
+  fetchMyReviewsApi,
+  updateReviewApi,
+  deleteReviewApi,
+} from "@/api/reviewApi";
 import { useAuthStore } from "@/stores/authStore";
 
 export function useMyReviews() {
   const authStore = useAuthStore();
+  const queryClient = useQueryClient();
 
-  return useQuery({
-    queryKey: computed(() => ["my-reviews"]),
+  // 1. 조회
+  const query = useQuery({
+    queryKey: ["my-reviews"],
     enabled: computed(() => authStore.isLoggedIn),
     queryFn: async () => {
       const res = await fetchMyReviewsApi();
@@ -19,4 +25,29 @@ export function useMyReviews() {
     },
     staleTime: 1000 * 30,
   });
+
+  // 2. 삭제 Mutation
+  const deleteMutation = useMutation({
+    mutationFn: (reviewId) => deleteReviewApi(reviewId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["my-reviews"] });
+    },
+  });
+
+  // 3. 수정 Mutation
+  const updateMutation = useMutation({
+    mutationFn: ({ reviewId, data }) => updateReviewApi(reviewId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["my-reviews"],
+        refetchType: "active",
+      });
+    },
+  });
+
+  return {
+    ...query,
+    deleteReview: deleteMutation.mutateAsync,
+    updateReview: updateMutation.mutateAsync,
+  };
 }

--- a/BookSpace/frontend/src/composables/profile/useMyWishes.js
+++ b/BookSpace/frontend/src/composables/profile/useMyWishes.js
@@ -3,10 +3,13 @@ import { useQuery } from "@tanstack/vue-query";
 import { useAuthStore } from "@/stores/authStore";
 import wishApi from "@/api/wishApi";
 
+// 찜 토글 성공 후 해당 키 invalidate
+export const myWishesQueryKey = () => ["my-wishes"];
+
 export function useMyWishes() {
   const authStore = useAuthStore();
   return useQuery({
-    queryKey: computed(() => ["my-wishes"]),
+    queryKey: computed(() => myWishesQueryKey()),
     enabled: authStore.isLoggedIn,
     queryFn: async () => {
       const res = await wishApi.getMyWishes();

--- a/BookSpace/frontend/src/composables/useRequireAuth.js
+++ b/BookSpace/frontend/src/composables/useRequireAuth.js
@@ -1,0 +1,86 @@
+/*
+# useRequireAuth
+- 로그인이 필요한 action을 감싸는 헬퍼
+- 버튼 클릭 / 토글 / api 요청 등 행동 단위 로그인 여부 체크
+- 비로그인일 때: toast + 로그인 페이지로 보내기
+- 로그인일 때: action 실행
+
+[사용]
+const {requireAuth} = useRequireAuth();
+const onWriteReview = requireAuth(
+  () => openReviewModal(),
+  {
+    loginMessage: "리뷰 작성은 로그인 후 가능합니다",
+  }
+);
+*/
+export function useRequireAuth(options = {}) {
+  const { loginMessage = "로그인 후 이용 가능한 서비스입니다", onBlocked } =
+    options;
+
+  const router = useRouter(); // 이동 제어
+  const route = useRoute(); // 현재 위치
+  const authStore = useAuthStore(); // 로그인 상태
+  const { toast } = useToast(); // 알림 ui
+
+  // 로그인 후 돌아갈 경로
+  const resolveRedirectPath = (redirectTarget) => {
+    if (!redirectTarget) return route.fullPath || "/";
+    const resolved = router.resolve(redirectTarget);
+    return resolved?.fullPath || resolved?.path || route.fullPath || "/";
+  };
+
+  // 로그인 페이지로 이동시키는 함수
+  const redirectToLogin = (redirectTarget) => {
+    router.push({
+      name: "signin",
+      query: { redirect: resolveRedirectPath(redirectTarget) },
+    });
+  };
+
+  const requireAuth = (action, actionOptions = {}) => {
+    const redirectTarget = actionOptions.redirect;
+    const localLoginMessage =
+      actionOptions.loginMessage !== undefined
+        ? actionOptions.loginMessage
+        : loginMessage;
+    const localOnBlocked = actionOptions.onBlocked || onBlocked;
+
+    return async (...args) => {
+      if (authStore.isLoggedIn) {
+        return typeof action === "function" ? action(...args) : undefined;
+      }
+
+      if (localLoginMessage) {
+        if (toast) {
+          toast({
+            title: localLoginMessage,
+            description: "로그인 후 이용해주세요.",
+          });
+        } else {
+          alert(localLoginMessage);
+        }
+      }
+
+      if (typeof localOnBlocked === "function") {
+        localOnBlocked();
+      }
+
+      redirectToLogin(redirectTarget);
+      return undefined;
+    };
+  };
+
+  return {
+    isLoggedIn: computed(() => authStore.isLoggedIn),
+    requireAuth,
+    redirectToLogin,
+  };
+}
+
+export default useRequireAuth;
+
+import { useRoute, useRouter } from "vue-router";
+import { computed } from "vue";
+import { useAuthStore } from "@/stores/authStore";
+import { useToast } from "@/composables/useToast";

--- a/BookSpace/frontend/src/main.js
+++ b/BookSpace/frontend/src/main.js
@@ -5,6 +5,7 @@ import router from "./router";
 import "./styles/global.css";
 import PrimeVue from "primevue/config";
 import { VueQueryPlugin } from "@tanstack/vue-query";
+import { queryClient } from "./plugins/vueQuery";
 
 const app = createApp(App);
 
@@ -20,16 +21,6 @@ app.use(PrimeVue, {
 });
 
 // vue query 플러그인 등록
-app.use(VueQueryPlugin, {
-  queryClientConfig: {
-    defaultOptions: {
-      queries: {
-        retry: 1, // 쿼리 실패 시 재시도 횟수
-        staleTime: 1000 * 60 * 1, // 1분 동안 fresh 데이터로 간주
-        cacheTime: 1000 * 60 * 5, // 5 동안 캐시 유지
-      },
-    },
-  },
-});
+app.use(VueQueryPlugin, { queryClient });
 
 app.mount("#app");

--- a/BookSpace/frontend/src/plugins/vueQuery.js
+++ b/BookSpace/frontend/src/plugins/vueQuery.js
@@ -1,0 +1,11 @@
+import { QueryClient } from "@tanstack/vue-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 1000 * 60 * 1, // 1 min
+      cacheTime: 1000 * 60 * 5, // 5mins
+    },
+  },
+});

--- a/BookSpace/frontend/src/router/index.js
+++ b/BookSpace/frontend/src/router/index.js
@@ -72,7 +72,11 @@ const router = createRouter({
   ],
 });
 
-// 전역 가드 추가: 인증이 필요한 페이지 접근 제어
+/* 
+전역 가드 추가: 인증이 필요한 페이지 접근 제어
+- meta: {requiresAuth:true} // 로그인 여부 체크
+- 페이지 단위 로그인 요구 처리 (기능 단위 로그인 요구 처리는 composables > useRequireAuth)
+*/
 router.beforeEach((to) => {
   const authStore = useAuthStore();
 

--- a/BookSpace/frontend/src/stores/wishStore.js
+++ b/BookSpace/frontend/src/stores/wishStore.js
@@ -1,5 +1,7 @@
 import { defineStore } from "pinia";
 import wishApi from "@/api/wishApi";
+import { queryClient } from "../plugins/vueQuery";
+import { myWishesQueryKey } from "../composables/profile/useMyWishes";
 
 /**
  * Wish(찜) Store
@@ -70,6 +72,8 @@ export const useWishStore = defineStore("wish", {
           }
           await wishApi.removeWish(bookId);
         }
+        // 찜 토글 후 내 찜 목록 쿼리 무효화 -> 최신화
+        queryClient.invalidateQueries({ queryKey: myWishesQueryKey() });
       } catch (err) {
         // 3. 실패 시 롤백
         this.isWishedByIsbn[isbn] = prev;

--- a/BookSpace/frontend/src/views/CommunityView.vue
+++ b/BookSpace/frontend/src/views/CommunityView.vue
@@ -92,13 +92,13 @@ import { fetchPosts } from "../api/postApi.js";
 import { computed, onMounted, ref, onUnmounted, watch, nextTick } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useToast } from "@/composables/useToast";
-import { useAuthStore } from "@/stores/authStore";
+import useRequireAuth from "@/composables/useRequireAuth";
 import ScrollTopButton from "@/components/common/ScrollTopButton.vue";
 
-const authStore = useAuthStore();
 const route = useRoute();
 const router = useRouter();
 const { toast } = useToast();
+const { requireAuth } = useRequireAuth();
 
 const pickQueryString = (value) =>
   Array.isArray(value) ? value[0] ?? "" : value ?? "";
@@ -299,20 +299,15 @@ const handleSortChange = async (nextSort) => {
   window.scrollTo({ top: 0, behavior: "smooth" });
 };
 
-const goToCreatePost = () => {
-  if (!authStore.isLoggedIn) {
+const goToCreatePost = requireAuth(() => router.push({ name: "postCreate" }), {
+  redirect: { name: "postCreate" },
+  loginMessage: null,
+  onBlocked: () =>
     toast({
       title: "로그인이 필요한 서비스입니다.",
       description: "게시글을 작성하려면 먼저 로그인해주세요.",
-    });
-    router.push({
-      name: "signin",
-      query: { redirect: router.resolve({ name: "postCreate" }).path },
-    });
-    return;
-  }
-  router.push({ name: "postCreate" });
-};
+    }),
+});
 
 // 새 게시글 보기 버튼 클릭 시 최신 데이터로 갱신 + 상단 이동
 const showLatestPosts = async () => {

--- a/BookSpace/frontend/src/views/ProfileView.vue
+++ b/BookSpace/frontend/src/views/ProfileView.vue
@@ -63,7 +63,12 @@
       maxWidth="max-w-3xl"
       @close="closeReviewModal"
     >
-      <ReviewDetailModal v-if="selectedReview" :review="selectedReview" />
+      <ReviewDetailModal
+        v-if="selectedReview"
+        :review="selectedReview"
+        @update="handleUpdateReview"
+        @delete="handleDeleteReview"
+      />
     </BaseModal>
 
     <!-- 도서 상세 모달 -->
@@ -72,7 +77,11 @@
       maxWidth="max-w-5xl"
       @close="closeBookModal"
     >
-      <BookDetailView v-if="selectedBookIsbn" :isbn="selectedBookIsbn" />
+      <BookDetailView
+        v-if="selectedBookIsbn"
+        :isbn="selectedBookIsbn"
+        @wish-updated="handleWishUpdated"
+      />
     </BaseModal>
     <ScrollTopButton />
   </div>
@@ -106,8 +115,18 @@ const nickname = computed(() => me.value?.userNickname);
 const activeTab = ref("wish");
 
 // vue-query
-const { data: wishItems, isLoading: loadingWishes } = useMyWishes(userId);
-const { data: reviewItems, isLoading: loadingReviews } = useMyReviews();
+const {
+  data: wishItems,
+  isLoading: loadingWishes,
+  refetch: refetchWishes,
+} = useMyWishes(userId);
+const {
+  data: reviewItems,
+  isLoading: loadingReviews,
+  refetch: refetchReviews,
+  updateReview,
+  deleteReview,
+} = useMyReviews();
 const { data: postItems, isLoading: loadingPosts } = useMyPosts();
 
 const safeWishItems = computed(() => wishItems.value ?? []);
@@ -127,6 +146,33 @@ const closeReviewModal = () => {
   selectedReview.value = null;
 };
 
+// 리뷰 핸들러
+
+const handleUpdateReview = async ({ reviewId, rating, content }) => {
+  try {
+    const updated = await updateReview({
+      reviewId,
+      data: { reviewRating: rating, reviewContent: content },
+    });
+    alert("수정되었습니다.");
+    closeReviewModal();
+  } catch (e) {
+    alert(e.response?.data?.message || "수정 실패");
+  }
+};
+
+const handleDeleteReview = async (review) => {
+  if (!review?.reviewId || !confirm("리뷰를 삭제할까요?")) return;
+
+  try {
+    await deleteReview(review.reviewId);
+    alert("삭제되었습니다.");
+    closeReviewModal();
+  } catch (e) {
+    alert(e.response?.data?.message || "삭제 실패");
+  }
+};
+
 // 포스트 모달 open & close
 const openPostModal = (post) => {
   selectedPostId.value = post?.postId ?? post?.id ?? null;
@@ -144,5 +190,9 @@ const openBookModal = (book) => {
 
 const closeBookModal = () => {
   selectedBookIsbn.value = null;
+};
+
+const handleWishUpdated = async () => {
+  await refetchWishes();
 };
 </script>


### PR DESCRIPTION
## PR Summary

- **Type**: feat
- **Scope**: FE(profile, auth)
- **Issue**: #120 

---

## Changes

- vue-query `queryClient` 전역화 및 찜 토글 후 캐시 무효화 처리
- 찜/찜 취소 후 모달 종료 시 마이페이지 찜 목록 즉시 반영
- 기능 단위 로그인 요구 처리를 위한 `useRequireAuth` composable 도입
- CommunityView 등 버튼/액션 단위 로그인 요구 로직 정리
- ProfileView 리뷰 수정/삭제 로직을 composable 기반으로 분리

### Frontend

- **UI/UX**
  - 리뷰 수정 후 모달 닫기 및 리스트 기준 결과 확인 UX로 정리
  - 찜 토글 후 마이페이지 찜 목록 즉시 반영

- **State / Data Flow**
  - vue-query `queryClient` 전역 관리 (`plugins/vueQuery`)
  - `useMyWishes`에서 queryKey export → wishStore에서 invalidate 처리
  - 리뷰 상세 모달은 로컬 state, 목록은 vue-query 캐시 기준으로 관리

- **API Integration**
  - `/wishes/me`, `/reviews/me` 캐시 invalidate 전략 정리
  - 리뷰 수정/삭제 mutation 성공 후 캐시 무효화 처리

- **Routing**
  - 전역 가드: 페이지 단위 로그인 요구 유지
  - `useRequireAuth`: 버튼/기능 단위 로그인 요구 처리

---

### Backend

- N/A
---

## How to Test
1. 로그인 후 마이페이지 진입
2. 찜 목록에서 도서 찜/찜 취소 → 모달 닫기
3. 찜 목록이 즉시 반영되는지 확인
4. 리뷰 수정 시 내용 변경 전에는 수정 버튼 비활성화 상태 확인
5. 리뷰 수정/삭제 후 모달 닫기 → 리스트에 즉시 반영되는지 확인

