### PR TITLE
[refactor] AI 도서추천 매칭 로직 개선 (#128)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/aiRecommendation/aiClient/OpenAiClient.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/aiRecommendation/aiClient/OpenAiClient.java
@@ -29,19 +29,56 @@ public class OpenAiClient {
 
     // JSON 강제 시스템 프롬프트 (너가 준 프롬프트 + JSON 출력 규칙 추가)
     private static final String SYSTEM_PROMPT = """
-    - 입력값이 "안녕", "배고파" 등 도서 추천과 무관한 경우 is_valid를 false로 반환.
-    
-    Example 1 (Invalid Input):
-    Input: "지금 점심 메뉴 추천해줘."
-    Output: {
-      "is_valid": false,
-      "user_emotion": "도서 추천과 무관한 일상적인 질문",
-      "comfort_message": "저는 당신의 마음을 읽는 독서 메이트예요! 지금 느끼는 감정을 알려주시면 그에 딱 맞는 책을 추천해 드릴게요.",
-      "book_titles": []
-    }
-
-    # Final Instruction
-    반드시 위의 JSON 형식만 출력하며, 마크다운 코드 블록(```json)을 포함하지 않은 순수 JSON 텍스트만 반환하라.
+             #Role
+             너는 10000권의 책을 알고 있는 도서관 사서야.\s
+             사용자의 문장에서 사용자의 상황과 심리를 파악하여 책을 추천해주는 전문가야.
+            
+             # Task
+             1. [감정 분석]: 사용자의 입력에서 느껴지는 주요 감정(기쁨, 슬픔, 불안, 분노, 무력감 등)을 파악해
+             2. [공감의 말]: 분석된 감정에 대해 진정성 있는 공감의 메시지를 먼저 건네줘.
+       
+            
+             # Logic (Chain of Thought)
+             - 알라딘, 교보문고, 예스24 등 한국의 도서 판매 플랫폼의 도서 책 소개 혹은 줄거리 등을 참고해.
+             - 베스트셀러로 추천해.
+             - 사용자의 상황에 맞는 도서를 추천해.
+            
+             # Constraints
+             - 한국에 정식 출간된 도서 위주로 추천할 것.
+             - 장르는 소설, 에세이, 인문학, 시집 등 다양하게 고려할 것.
+             - 도서의 정확한 제목만 쓰고, 부제 혹은 시리즈 정보는 제공하지 말 것.
+             - 답변 톤: 따뜻하고 다정하며 지적인 느낌을 유지할 것.
+            
+             # Output Format
+             반드시 아래 JSON 스키마로만 응답해. JSON 이외의 텍스트(설명, 문장, 마크다운, 코드블록)를 절대 출력하지 마.
+             키 이름은 반드시 아래와 동일하게 사용해.
+              
+              Output: {
+              "is_valid": true,
+              "user_emotion": "도서 추천과 무관한 일상적인 질문",
+              "comfort_message": "저는 당신의 마음을 읽는 독서 메이트예요! 지금 느끼는 감정을 알려주시면 그에 딱 맞는 책을 추천해 드릴게요.",
+              "books": [
+                 {
+                    "title": "추천하는 도서 제목",
+                    "reason": "추천이유 1문장"
+                 }
+               ]
+             }
+            
+              Output: {
+              "is_valid": false,
+              "user_emotion": "도서 추천과 무관한 일상적인 질문",
+              "comfort_message": "저는 당신의 마음을 읽는 독서 메이트예요! 지금 느끼는 감정을 알려주시면 그에 딱 맞는 책을 추천해 드릴게요.",
+              "books": []
+              }
+            
+             추가 규칙:
+             - 사용자 입력이 도서/감정/독서와 무관하면 is_valid=false로 응답하고,
+               comfort_message에 "도서 추천 관련 질문만 도와줄 수 있어요"처럼 유도 문구를 넣어.
+               이 경우 recommendations는 빈 배열 []로 반환해.
+             - 추천 도서의 제목은 정확해야 해.
+             ""\";
+                                                                                                    
 """;
 
 
@@ -82,7 +119,7 @@ public class OpenAiClient {
             ApiResponseDto dto = om.readValue(onlyJson, ApiResponseDto.class);
 
             // 최소 검증: book_titles가 null이면 빈 리스트로
-            if (dto.book_titles == null) dto.book_titles = List.of();
+            if (dto.books == null) dto.books = List.of();
 
             return dto;
 
@@ -93,7 +130,7 @@ public class OpenAiClient {
             fallback.is_valid = false;
             fallback.user_emotion = null;
             fallback.comfort_message = "AI 응답을 처리하는 중 오류가 발생했어요. 잠시 후 다시 시도해주세요.";
-            fallback.book_titles = List.of();
+            fallback.books = List.of();
             return fallback;
         }
     }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/aiRecommendation/dto/AiRecommendationResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/aiRecommendation/dto/AiRecommendationResponseDto.java
@@ -26,8 +26,9 @@ public class AiRecommendationResponseDto {
     @NoArgsConstructor
     public static class BookItem {
 
-        private Long bookId;
+        private String reason;
 
+        private Long bookId;
         private String isbn13;
         private String title;
         private String author;

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/aiRecommendation/dto/ApiResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/aiRecommendation/dto/ApiResponseDto.java
@@ -10,5 +10,10 @@ public class ApiResponseDto {
     public boolean is_valid;
     public String user_emotion;
     public String comfort_message;
-    public List<String> book_titles;
+    public List<AiRecommendationItemDto> books; // ✅ 변경
+
+    public static class AiRecommendationItemDto {
+        public String title;
+        public String reason;
+    }
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/aiRecommendation/service/AiRecommendationServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/aiRecommendation/service/AiRecommendationServiceImpl.java
@@ -36,7 +36,7 @@ public class AiRecommendationServiceImpl implements AiRecommendationService {
         // 1) OpenAI 호출 (제목 3개 + 감정/위로 메시지)
         ApiResponseDto apiDto = openAiClient.requestJson(userRequest);
 
-        if (apiDto == null || apiDto.book_titles == null || apiDto.book_titles.isEmpty()) {
+        if (apiDto == null || apiDto.books == null || apiDto.books.isEmpty()) {
             return buildFailResponse(
                     "지금 마음에 맞는 책을 찾기 어려웠어요. 감정이나 상황을 조금만 더 구체적으로 말해줄래요? 🙂"
             );
@@ -45,7 +45,12 @@ public class AiRecommendationServiceImpl implements AiRecommendationService {
         // 2) 제목 → 검색 → isbn13 → 상세 조회
         List<AiRecommendationResponseDto.BookItem> items = new ArrayList<>();
 
-        for (String title : apiDto.book_titles) {
+        for (ApiResponseDto.AiRecommendationItemDto b : apiDto.books) {
+            if (b == null) continue;
+
+            String title = b.title;
+            String reason = b.reason;
+
             if (title == null || title.isBlank()) continue;
 
             String isbn13 = resolveIsbn13ByTitle(title);
@@ -61,7 +66,7 @@ public class AiRecommendationServiceImpl implements AiRecommendationService {
             AiRecommendationResponseDto.BookItem item =
                     new AiRecommendationResponseDto.BookItem();
 
-            item.setBookId(detail.getBookId());                // ⭐ Long (없으면 null)
+            item.setBookId(detail.getBookId());
             item.setIsbn13(detail.getIsbn());
             item.setTitle(detail.getTitle());
             item.setAuthor(detail.getAuthor());
@@ -70,7 +75,7 @@ public class AiRecommendationServiceImpl implements AiRecommendationService {
             item.setAverageRating(
                     detail.getAverageRating() != null ? detail.getAverageRating() : 0.0
             );
-
+            item.setReason(reason != null ? reason.trim() : null);
             items.add(item);
             if (items.size() == 3) break;
         }
@@ -108,7 +113,10 @@ public class AiRecommendationServiceImpl implements AiRecommendationService {
         }
 
         if (results == null || results.isEmpty()) return null;
-        return results.get(0).getIsbn13();
+
+        BookSearchResponseDto best = pickBestByTitle(normalized, results);
+
+        return best != null ? best.getIsbn13() : null;
     }
 
     private String normalizeTitle(String raw) {
@@ -125,5 +133,70 @@ public class AiRecommendationServiceImpl implements AiRecommendationService {
         fail.setComfortMessage(message);
         fail.setRecommendations(List.of());
         return fail;
+    }
+
+    private BookSearchResponseDto pickBestByTitle(String normalizedQuery, List<BookSearchResponseDto> results) {
+        BookSearchResponseDto best = null;
+        int bestScore = Integer.MIN_VALUE;
+
+        for (BookSearchResponseDto r : results) {
+            if (r == null || r.getTitle() == null || r.getTitle().isBlank()) continue;
+
+            String normalizedTitle = normalizeTitle(r.getTitle());
+            if (normalizedTitle.isBlank()) continue;
+
+            int score = scoreTitleMatch(normalizedQuery, normalizedTitle);
+
+            if (score > bestScore) {
+                bestScore = score;
+                best = r;
+            }
+        }
+
+        // 너무 애매하게 매칭되면 null로 처리해서 스킵하도록(선택)
+        // if (bestScore < 40) return null;
+
+        return best;
+    }
+
+    private int scoreTitleMatch(String q, String t) {
+        // 1) 완전일치
+        if (t.equals(q)) return 1000;
+
+        // 2) 접두어 일치(표기/공백 차이 대응)
+        if (t.startsWith(q) || q.startsWith(t)) return 900;
+
+        // 3) 포함 관계
+        if (t.contains(q) || q.contains(t)) return 800;
+
+        // 4) 토큰(단어) 겹침 점수
+        List<String> qTokens = tokenize(q);
+        List<String> tTokens = tokenize(t);
+
+        int intersect = 0;
+        for (String tok : qTokens) {
+            if (tTokens.contains(tok)) intersect++;
+        }
+
+        int union = qTokens.size() + tTokens.size() - intersect;
+        double jaccard = union == 0 ? 0 : (double) intersect / union;
+
+        int lenPenalty = Math.abs(q.length() - t.length());
+        int tokenScore = (int) Math.round(jaccard * 100);
+
+        return tokenScore * 5 - lenPenalty; // 가중치는 필요하면 조절
+    }
+
+    private List<String> tokenize(String s) {
+        if (s == null) return List.of();
+        String[] parts = s.split("\\s+");
+
+        List<String> tokens = new ArrayList<>();
+        for (String p : parts) {
+            if (p == null || p.isBlank()) continue;
+            if (p.length() <= 1) continue; // 1글자 토큰 제거(노이즈 감소)
+            tokens.add(p);
+        }
+        return tokens;
     }
 }


### PR DESCRIPTION
##  작업 내용
AI 도서 추천 결과의 반복/편향을 줄이기 위해 제목 → ISBN 매칭 로직을 개선

---

## 주요 변경사항
- OpenAI 프롬프트 수정
  - Role, Task, Logic, Constraints 보완
  - 각 도서에 대한 추천 이유 1문장 추가
- 검색 결과 0번 고정 선택 제거
  - 기존: `searchBooks()` 결과의 `results.get(0)`을 그대로 사용해 특정 도서로 반복 매칭되는 현상 발생
  - 변경: 검색 결과 중 **입력 제목과 가장 잘 맞는 결과(best match)** 를 선택하도록 개선

- 제목 유사도 기반 매칭 로직 추가
  - 제목 정규화(`normalizeTitle`) 후 비교
  - 우선순위 기반 점수화:
    - 완전 일치 > startsWith > contains > 토큰(단어) 겹침 점수(Jaccard 유사도)
  - 결과 중 가장 점수가 높은 항목을 선택해 ISBN 반환
