### PR TITLE
[Edit] 게시물 상세 조회 - 조회수 증가 조건 처리 (X-Skip-View-Count) (#133)

### DIFF
--- a/BookSpace/backend/.idea/modules/bookspace.test.iml
+++ b/BookSpace/backend/.idea/modules/bookspace.test.iml
@@ -3,6 +3,7 @@
   <component name="AdditionalModuleElements">
     <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test">
       <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test" isTestSource="true" generated="true" />
     </content>
   </component>
 </module>

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/controller/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
      */
     @GetMapping
     public ResponseEntity<PostPageResponseDto> getAllPosts(@RequestParam(defaultValue = "0") int page,
-                                                                 @RequestParam(defaultValue = "10") int size,
+                                                           @RequestParam(defaultValue = "10") int size,
                                                            @RequestParam(required = false) String isbn,
                                                            @RequestParam(required = false,defaultValue = "latest") String sort,
                                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -55,9 +55,11 @@ public class PostController {
 
     // 3. 단건 조회
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponseDto> getPost(@PathVariable long postId, @AuthenticationPrincipal CustomUserDetails user  ) {
+    public ResponseEntity<PostResponseDto> getPostById(@PathVariable long postId, @AuthenticationPrincipal CustomUserDetails user,
+        @RequestHeader(value="X-Skip-View-Count", required = false) String skipViewCount) {
         Long userId = (user!=null)?user.getUserId():null;
-        PostResponseDto response = postService.getPostById(postId, userId);
+        boolean shouldIncreaseView = !"true".equals(skipViewCount);
+        PostResponseDto response = postService.getPostById(postId, userId, shouldIncreaseView);
         return ResponseEntity.ok(response);
     }
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostService.java
@@ -15,7 +15,7 @@ public interface PostService {
     PostPageResponseDto getAllPosts(int page, int size, String isbn, String sort, Long userId);
 
     // 게시글 단건 조회
-    PostResponseDto getPostById(long postId, Long userId);
+    PostResponseDto getPostById(long postId, Long userId, boolean shouldIncreaseView);
 
     // 게시글 수정
     void updatePost(long postId, PostRequestDto requestDto, long loginUserId);

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/post/service/PostServiceImpl.java
@@ -108,7 +108,7 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional
-    public PostResponseDto getPostById(long postId, Long userId) {
+    public PostResponseDto getPostById(long postId, Long userId, boolean shouldIncreaseView) {
 
         PostResponseDto responseDto = postDao.selectPostById(postId,userId);
 
@@ -116,7 +116,12 @@ public class PostServiceImpl implements PostService {
             throw new IllegalArgumentException("Post not found with id: " + postId);
         }
 
-        postDao.increaseViewCount(postId);
+        if(shouldIncreaseView){
+            postDao.increaseViewCount(postId);
+            // 증가된 조회수를 응답에 반영 (사용자에게 즉시 보여주기 위해)
+            responseDto.setPostViewCnt(responseDto.getPostViewCnt() + 1);
+        }
+
         return responseDto;
     }
 


### PR DESCRIPTION
## PR Summary

- **Type**: fix
- **Scope**: BE(Post)
- **Issue**:  #106/ Refs #

## Changes

### Frontend

- N/A

### Backend

- **게시글 단건 조회 조회수 증가 조건 처리**
    - `GET /posts/{postId}`에서 `X-Skip-View-Count` 헤더 지원
    - `X-Skip-View-Count: true` 인 경우 조회수 증가 로직 스킵
    - 서비스 로직에 `shouldIncreaseView` 플래그 추가하여 조회수 증가 여부 제어
    - 조회수 증가 시, 응답 DTO에도 증가된 조회수를 즉시 반영하도록 처리

## How to Test

- (기본) `GET /posts/{postId}` 호출 → 조회수가 1 증가하는지 확인
- `GET /posts/{postId}` 호출 시 헤더 `X-Skip-View-Count: true` 포함 → 조회수가 증가하지 않는지 확인
- 조회수 증가 케이스에서 응답의 `postViewCnt`가 즉시 +1로 내려오는지 확인