### PR TITLE
[Feat] 회원가입 & 비밀번호 찾기 이메일 인증 기능 구현 및 PostCard 컴포넌트 수정 (#145)

### DIFF
--- a/BookSpace/backend/src/main/java/com/bookspace/domain/email/controller/EmailVerificationController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/email/controller/EmailVerificationController.java
@@ -23,7 +23,13 @@ public class EmailVerificationController {
     public ResponseEntity<EmailVerificationResponseDto> sendVerificationCode(
             @RequestBody EmailVerificationRequestDto dto) {
         try {
-            emailVerificationService.sendVerificationCode(dto.getEmail());
+            if (dto.getEmail() == null || dto.getEmail().trim().isEmpty()) {
+                return ResponseEntity.badRequest().body(new EmailVerificationResponseDto(
+                        false,
+                        "이메일 주소를 입력해주세요."
+                ));
+            }
+            emailVerificationService.sendVerificationCode(dto.getEmail().trim());
             return ResponseEntity.ok(new EmailVerificationResponseDto(
                     true,
                     "인증 코드가 이메일로 발송되었습니다."
@@ -31,7 +37,7 @@ public class EmailVerificationController {
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(new EmailVerificationResponseDto(
                     false,
-                    "이메일 발송에 실패했습니다. 이메일 주소를 확인해주세요."
+                    e.getMessage() != null ? e.getMessage() : "이메일 발송에 실패했습니다. 이메일 주소를 확인해주세요."
             ));
         }
     }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/email/service/EmailVerificationService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/email/service/EmailVerificationService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
@@ -24,20 +25,36 @@ public class EmailVerificationService {
     private boolean devMode;
 
     // 발신자 이메일 (Gmail 계정)
-    @Value("${spring.mail.username}")
+    @Value("${spring.mail.username:}")
     private String fromEmail;
 
     // 인증 코드 저장소 (이메일 -> 코드 정보)
     private final Map<String, VerificationCode> codeStorage = new ConcurrentHashMap<>();
 
-    // 인증 완료된 이메일 저장소
+    // 인증 완료된 이메일 저장소 (임시, 1시간 유효)
     private final Map<String, LocalDateTime> verifiedEmails = new ConcurrentHashMap<>();
+
+    // 가입 시 영구 인증 완료된 이메일 저장소 (영구)
+    private final Set<String> permanentlyVerifiedEmails = ConcurrentHashMap.newKeySet();
+
+    // 비밀번호 재설정 토큰 저장소 (토큰 -> 이메일, 1시간 유효)
+    private final Map<String, ResetToken> resetTokens = new ConcurrentHashMap<>();
 
     // 인증 코드 유효 시간 (5분)
     private static final int CODE_EXPIRY_MINUTES = 5;
 
+    // 재설정 토큰 유효 시간 (1시간)
+    private static final int RESET_TOKEN_EXPIRY_HOURS = 1;
+
     // 인증 코드 정보
     private record VerificationCode(String code, LocalDateTime expiryTime) {
+        boolean isExpired() {
+            return LocalDateTime.now().isAfter(expiryTime);
+        }
+    }
+
+    // 재설정 토큰 정보
+    private record ResetToken(String email, LocalDateTime expiryTime) {
         boolean isExpired() {
             return LocalDateTime.now().isAfter(expiryTime);
         }
@@ -93,6 +110,21 @@ public class EmailVerificationService {
     }
 
     /**
+     * 가입 시 이메일 인증 완료를 영구적으로 저장
+     */
+    public void markEmailAsPermanentlyVerified(String email) {
+        permanentlyVerifiedEmails.add(email.toLowerCase());
+        log.info("Email marked as permanently verified: {}", email);
+    }
+
+    /**
+     * 가입 시 이메일 인증 완료 여부 확인 (영구)
+     */
+    public boolean isEmailPermanentlyVerified(String email) {
+        return permanentlyVerifiedEmails.contains(email.toLowerCase());
+    }
+
+    /**
      * 이메일 인증 여부 확인
      */
     public boolean isEmailVerified(String email) {
@@ -115,6 +147,51 @@ public class EmailVerificationService {
     }
 
     /**
+     * 비밀번호 재설정 링크 발송
+     */
+    public String sendPasswordResetLink(String email) {
+        // 재설정 토큰 생성
+        String token = generateResetToken();
+        
+        // 저장 (1시간 후 만료)
+        resetTokens.put(token, new ResetToken(
+                email,
+                LocalDateTime.now().plusHours(RESET_TOKEN_EXPIRY_HOURS)
+        ));
+
+        // 이메일 발송
+        sendPasswordResetLinkEmail(email, token);
+
+        log.info("Password reset link sent to: {}", email);
+        return token;
+    }
+
+    /**
+     * 재설정 토큰 검증
+     */
+    public String verifyResetToken(String token) {
+        ResetToken stored = resetTokens.get(token);
+
+        if (stored == null) {
+            log.warn("No reset token found: {}", token);
+            return null;
+        }
+
+        if (stored.isExpired()) {
+            resetTokens.remove(token);
+            log.warn("Reset token expired: {}", token);
+            return null;
+        }
+
+        // 토큰 사용 후 삭제
+        String email = stored.email();
+        resetTokens.remove(token);
+        
+        log.info("Reset token verified successfully for: {}", email);
+        return email;
+    }
+
+    /**
      * 6자리 인증 코드 생성
      */
     private String generateCode() {
@@ -124,14 +201,24 @@ public class EmailVerificationService {
     }
 
     /**
+     * 재설정 토큰 생성 (32자리 랜덤 문자열)
+     */
+    private String generateResetToken() {
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[24];
+        random.nextBytes(bytes);
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    /**
      * 이메일 발송
      */
     private void sendEmail(String to, String code) {
         // 개발 모드: 실제 이메일 발송 대신 콘솔에 출력
         if (devMode) {
             log.info("========================================");
-            log.info("📧 [DEV MODE] 이메일 인증 코드");
-            log.info("📬 수신자: {}", to);
+            log.info(" [DEV MODE] 이메일 인증 코드");
+            log.info("수신자: {}", to);
             log.info("🔑 인증 코드: {}", code);
             log.info("⏰ 유효 시간: 5분");
             log.info("========================================");
@@ -141,12 +228,15 @@ public class EmailVerificationService {
         // 프로덕션 모드: 실제 이메일 발송
         try {
             SimpleMailMessage message = new SimpleMailMessage();
-            message.setFrom(fromEmail); // 발신자 설정 (필수!)
+            // fromEmail이 비어있지 않으면 설정
+            if (fromEmail != null && !fromEmail.isEmpty()) {
+                message.setFrom(fromEmail);
+            }
             message.setTo(to);
             message.setSubject("[BookSpace] 이메일 인증 코드");
             message.setText(
                     "안녕하세요, BookSpace입니다.\n\n" +
-                    "회원가입 인증 코드: " + code + "\n\n" +
+                    "이메일 인증 코드: " + code + "\n\n" +
                     "이 코드는 5분간 유효합니다.\n" +
                     "본인이 요청하지 않은 경우 이 메일을 무시해주세요."
             );
@@ -154,7 +244,49 @@ public class EmailVerificationService {
             mailSender.send(message);
             log.info("Email sent successfully to: {}", to);
         } catch (Exception e) {
-            log.error("Failed to send email to {}: {}", to, e.getMessage());
+            log.error("Failed to send email to {}: {}", to, e.getMessage(), e);
+            throw new RuntimeException("이메일 발송에 실패했습니다. 이메일 주소를 확인해주세요.");
+        }
+    }
+
+    /**
+     * 비밀번호 재설정 링크 이메일 발송
+     */
+    private void sendPasswordResetLinkEmail(String to, String token) {
+        // 개발 모드: 실제 이메일 발송 대신 콘솔에 출력이
+        if (devMode) {
+            String resetLink = "http://localhost:5173/reset-password?token=" + token;
+            log.info("========================================");
+            log.info("📧 [DEV MODE] 비밀번호 재설정 링크");
+            log.info("📬 수신자: {}", to);
+            log.info("🔗 재설정 링크: {}", resetLink);
+            log.info("⏰ 유효 시간: {}시간", RESET_TOKEN_EXPIRY_HOURS);
+            log.info("========================================");
+            return;
+        }
+
+        // 프로덕션 모드: 실제 이메일 발송
+        try {
+            String resetLink = "http://localhost:5173/reset-password?token=" + token; // TODO: 프로덕션 URL로 변경 필요
+            SimpleMailMessage message = new SimpleMailMessage();
+            if (fromEmail != null && !fromEmail.isEmpty()) {
+                message.setFrom(fromEmail);
+            }
+            message.setTo(to);
+            message.setSubject("[BookSpace] 비밀번호 재설정 링크");
+            message.setText(
+                    "안녕하세요, BookSpace입니다.\n\n" +
+                    "비밀번호 재설정을 요청하셨습니다.\n\n" +
+                    "아래 링크를 클릭하여 비밀번호를 재설정하세요:\n" +
+                    resetLink + "\n\n" +
+                    "이 링크는 " + RESET_TOKEN_EXPIRY_HOURS + "시간간 유효합니다.\n" +
+                    "본인이 요청하지 않은 경우 이 메일을 무시해주세요."
+            );
+
+            mailSender.send(message);
+            log.info("Password reset link email sent successfully to: {}", to);
+        } catch (Exception e) {
+            log.error("Failed to send password reset link email to {}: {}", to, e.getMessage(), e);
             throw new RuntimeException("이메일 발송에 실패했습니다. 이메일 주소를 확인해주세요.");
         }
     }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/controller/UserController.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.bookspace.domain.user.dto.UserUpdateRequestDto;
 import com.bookspace.domain.user.dto.VerifyUserRequestDto;
 import com.bookspace.domain.user.dto.VerifyUserResponseDto;
 import com.bookspace.domain.user.dto.ResetPasswordRequestDto;
+import com.bookspace.domain.user.dto.ResetPasswordByTokenRequestDto;
 import com.bookspace.domain.user.service.UserService;
 import com.bookspace.global.security.userdetails.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -95,26 +96,31 @@ public class UserController {
     @GetMapping("/check")
     public ResponseEntity<Boolean> checkDuplicate(
             @RequestParam String type, @RequestParam String value) {
-
-        // switch expression 문법 사용
-        boolean exists = switch (type.toLowerCase()) {
-            case "loginid" -> userService.existsUserByLoginId(value);
-            case "nickname" -> userService.existsUserByNickname(value);
-            case "email" -> {
-                // 이메일 형식 간단 검증 (안전장치)
-                if (!value.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
-                    throw new IllegalArgumentException("Invalid email format: " + value);
+        try {
+            // switch expression 문법 사용
+            boolean exists = switch (type.toLowerCase()) {
+                case "loginid" -> userService.existsUserByLoginId(value);
+                case "nickname" -> userService.existsUserByNickname(value);
+                case "email" -> {
+                    // 이메일 형식 간단 검증 (안전장치)
+                    // @ 기호가 있고, 그 뒤에 도메인이 있는지만 확인
+                    if (value == null || value.trim().isEmpty() || !value.contains("@") || value.split("@").length != 2) {
+                        throw new RuntimeException("Invalid email format: " + value);
+                    }
+                    // yield : switch expression 안에서 값을 반환(return) 하는 최신 키워드
+                    yield userService.existsUserByEmail(value.trim());
                 }
-                // yield : switch expression 안에서 값을 반환(return) 하는 최신 키워드
-                yield userService.existsUserByEmail(value);
-            }
-            // loginid, nickname, email이 아닌 type이 들어왔을때 발생 메시지
-            default -> throw new IllegalArgumentException("Invalid type: " + type);
-        };
+                // loginid, nickname, email이 아닌 type이 들어왔을때 발생 메시지
+                default -> throw new RuntimeException("Invalid type: " + type);
+            };
 
-        // true = 사용 가능(중복 아님)
-        // false = 이미 존재
-        return ResponseEntity.ok(!exists);
+            // true = 사용 가능(중복 아님)
+            // false = 이미 존재
+            return ResponseEntity.ok(!exists);
+        } catch (Exception e) {
+            // 예외 발생 시 500 에러 대신 400 에러 반환
+            return ResponseEntity.badRequest().build();
+        }
     }
 
 
@@ -151,17 +157,37 @@ public class UserController {
 //        return ResponseEntity.ok(!exists);
 //    }
 
-    // 10. 비밀번호 찾기 - 본인 확인
+    // 10. 비밀번호 찾기 - 본인 확인 및 재설정 링크/코드 발송
     @PostMapping("/verify")
     public ResponseEntity<VerifyUserResponseDto> verifyUser(@RequestBody VerifyUserRequestDto dto) {
-        boolean verified = userService.verifyUser(dto.getUserLoginId(), dto.getUserEmail());
-        return ResponseEntity.ok(new VerifyUserResponseDto(verified));
+        try {
+            String resetLink = userService.sendPasswordResetCodeOrLink(dto.getUserLoginId(), dto.getUserEmail());
+            VerifyUserResponseDto response = new VerifyUserResponseDto();
+            response.setVerified(true);
+            response.setResetLink(resetLink);
+            response.setLinkSent(resetLink != null);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            // 본인 확인 실패
+            VerifyUserResponseDto response = new VerifyUserResponseDto();
+            response.setVerified(false);
+            response.setResetLink(null);
+            response.setLinkSent(false);
+            return ResponseEntity.ok(response);
+        }
     }
 
-    // 11. 비밀번호 재설정
+    // 11. 비밀번호 재설정 (코드 인증 후)
     @PostMapping("/reset-password")
     public ResponseEntity<Void> resetPassword(@RequestBody ResetPasswordRequestDto dto) {
         userService.resetPassword(dto.getUserLoginId(), dto.getUserEmail(), dto.getNewPassword());
+        return ResponseEntity.ok().build();
+    }
+
+    // 12. 비밀번호 재설정 (링크 토큰 사용)
+    @PostMapping("/reset-password-by-token")
+    public ResponseEntity<Void> resetPasswordByToken(@RequestBody ResetPasswordByTokenRequestDto dto) {
+        userService.resetPasswordByToken(dto.getToken(), dto.getNewPassword());
         return ResponseEntity.ok().build();
     }
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/dao/UserDao.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/dao/UserDao.java
@@ -19,6 +19,9 @@ public interface UserDao {
     // 4. 회원 정보 조회 (by userLoginId)
     UserVo selectUserByLoginId(@Param("userLoginId") String userLoginId);
 
+    // 4-1. 회원 정보 조회 (by userEmail)
+    UserVo selectUserByEmail(@Param("userEmail") String userEmail);
+
     // 5. 회원 탈퇴 (soft delete)
     int softDeleteUser(@Param("userId") long userId);
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/dto/VerifyUserResponseDto.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/dto/VerifyUserResponseDto.java
@@ -11,5 +11,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class VerifyUserResponseDto {
     private boolean verified;
+    private String resetLink; // 재설정 링크 (가입 시 이메일 인증 완료된 경우)
+    private boolean isLinkSent; // 링크 발송 여부 (true: 링크, false: 코드)
 }
 

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/service/UserService.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/service/UserService.java
@@ -46,4 +46,10 @@ public interface UserService {
 
     // 13. 비밀번호 재설정
     void resetPassword(String userLoginId, String userEmail, String newPassword);
+
+    // 14. 비밀번호 찾기 - 재설정 링크 또는 코드 발송 (가입 시 이메일 인증 완료 여부에 따라)
+    String sendPasswordResetCodeOrLink(String userLoginId, String userEmail);
+
+    // 15. 재설정 링크를 통한 비밀번호 재설정
+    void resetPasswordByToken(String token, String newPassword);
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/domain/user/service/UserServiceImpl.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/domain/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.bookspace.domain.user.service;
 
+import com.bookspace.domain.email.service.EmailVerificationService;
 import com.bookspace.domain.user.dao.UserDao;
 import com.bookspace.domain.user.dto.SignInRequestDto;
 import com.bookspace.domain.user.dto.SignupRequestDto;
@@ -20,6 +21,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserDao userDao;
     private final PasswordEncoder passwordEncoder;
+    private final EmailVerificationService emailVerificationService;
 
     // 1. 회원가입
     @Override
@@ -51,6 +53,9 @@ public class UserServiceImpl implements UserService {
         if (result != 1) {
             throw new IllegalStateException("Failed to create user.");
         }
+
+        // 가입 시 이메일 인증 완료를 영구적으로 저장
+        emailVerificationService.markEmailAsPermanentlyVerified(dto.getUserEmail());
 
         // insert 시 useGeneratedKeys 로 userId 세팅됨
         return convertToResponseDto(userVo);
@@ -230,6 +235,50 @@ public class UserServiceImpl implements UserService {
         return userEmail.equalsIgnoreCase(userVo.getUserEmail());
     }
 
+    // 14. 비밀번호 찾기 - 재설정 링크 또는 코드 발송
+    @Override
+    public String sendPasswordResetCodeOrLink(String userLoginId, String userEmail) {
+        // 본인 확인
+        if (!verifyUser(userLoginId, userEmail)) {
+            throw new IllegalArgumentException("사용자 정보가 일치하지 않습니다.");
+        }
+
+        // 가입 시 이메일 인증 완료 여부 확인
+        if (emailVerificationService.isEmailPermanentlyVerified(userEmail)) {
+            // 재설정 링크 발송
+            return emailVerificationService.sendPasswordResetLink(userEmail);
+        } else {
+            // 인증 코드 발송
+            emailVerificationService.sendVerificationCode(userEmail);
+            return null; // 링크가 아닌 코드 발송
+        }
+    }
+
+    // 15. 재설정 링크를 통한 비밀번호 재설정
+    @Override
+    @Transactional
+    public void resetPasswordByToken(String token, String newPassword) {
+        // 토큰 검증
+        String email = emailVerificationService.verifyResetToken(token);
+        if (email == null) {
+            throw new IllegalArgumentException("유효하지 않거나 만료된 재설정 링크입니다.");
+        }
+
+        // 이메일로 사용자 조회
+        UserVo userVo = userDao.selectUserByEmail(email);
+        if (userVo == null) {
+            throw new IllegalArgumentException("사용자를 찾을 수 없습니다.");
+        }
+
+        // 비밀번호 암호화 후 업데이트
+        String encodedPassword = passwordEncoder.encode(newPassword);
+        int result = userDao.updatePassword(userVo.getUserLoginId(), encodedPassword);
+
+        if (result != 1) {
+            throw new IllegalStateException("비밀번호 변경에 실패했습니다.");
+        }
+    }
+
     // 13. 비밀번호 재설정
     @Override
     @Transactional
@@ -239,6 +288,11 @@ public class UserServiceImpl implements UserService {
             throw new IllegalArgumentException("사용자 정보가 일치하지 않습니다.");
         }
 
+        // 이메일 인증 확인
+        if (!emailVerificationService.isEmailVerified(userEmail)) {
+            throw new IllegalStateException("이메일 인증이 완료되지 않았습니다. 이메일 인증을 먼저 완료해주세요.");
+        }
+
         // 비밀번호 암호화 후 업데이트
         String encodedPassword = passwordEncoder.encode(newPassword);
         int result = userDao.updatePassword(userLoginId, encodedPassword);
@@ -246,6 +300,9 @@ public class UserServiceImpl implements UserService {
         if (result != 1) {
             throw new IllegalStateException("비밀번호 변경에 실패했습니다.");
         }
+
+        // 비밀번호 재설정 완료 후 이메일 인증 상태 정리
+        emailVerificationService.clearVerification(userEmail);
     }
 
     // DTO 변환

--- a/BookSpace/backend/src/main/java/com/bookspace/global/exception/GlobalExceptionHandler.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/exception/GlobalExceptionHandler.java
@@ -67,4 +67,16 @@ public class GlobalExceptionHandler {
                 .build();
     }
 
+    /** 500 - Internal Server Error (예상치 못한 예외) */
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleException(Exception ex) {
+        // 로그에 전체 스택 트레이스 기록
+        ex.printStackTrace();
+        return ErrorResponse.builder()
+                .code("INTERNAL_SERVER_ERROR")
+                .message(ex.getMessage() != null ? ex.getMessage() : "서버 내부 오류가 발생했습니다.")
+                .build();
+    }
+
 }

--- a/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
+++ b/BookSpace/backend/src/main/java/com/bookspace/global/security/config/SecurityConfig.java
@@ -41,13 +41,13 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        // setAllowedOriginPatterns로 와일드카드 패턴 허용 (ngrok 등)
-        config.setAllowedOriginPatterns(List.of(
+                // setAllowedOriginPatterns로 와일드카드 패턴 허용 (ngrok 등)
+              config.setAllowedOriginPatterns(List.of(
                 "http://localhost:5173",
                 "http://localhost:4173",
                 "https://*.ngrok-free.app",
                 "https://*.ngrok-free.dev"
-        ));
+         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization", "Refresh-Token"));
@@ -68,7 +68,7 @@ public class SecurityConfig {
         JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(jwtTokenProvider,customUserDetailsService);
 
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 연결
+                .cors(cors->{})// cors 활성화
                 .csrf(csrf -> csrf.disable()) // 브라우저 기본 폼 요청 공격 방어 (주로 세션에서 사용됨)
                 .formLogin(form -> form.disable()) // 기본 폼 (/login) 비활성화 -> (/auth/login)
                 .httpBasic(basic -> basic.disable()) // 헤더에 id/pw 실어 보내는 basic 방식 비활성화
@@ -76,8 +76,6 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용 X
                 )
                 .authorizeHttpRequests(auth -> auth
-                        // CORS preflight 요청 허용
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/",
                                 "/login",
@@ -85,7 +83,7 @@ public class SecurityConfig {
                                 "/auth/**",
                                 "/books/**",
                                 "/users/**",
-                                "/email/**"  // 이메일 인증
+                                "/email/**"
                         ).permitAll() // 인증 없이 가능
                         .requestMatchers("/users/me/**").authenticated()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/posts/**").permitAll()
@@ -104,3 +102,4 @@ public class SecurityConfig {
         return http.build();
     }
 }
+

--- a/BookSpace/backend/src/main/resources/mappers/UserMapper.xml
+++ b/BookSpace/backend/src/main/resources/mappers/UserMapper.xml
@@ -80,6 +80,26 @@
         WHERE user_login_id = #{userLoginId}
     </select>
 
+    <!-- 4-1. 회원 정보 조회 (by userEmail) -->
+    <select id="selectUserByEmail" resultType="com.bookspace.domain.user.vo.UserVo">
+        SELECT
+            user_id,
+            user_login_id,
+            user_name,
+            user_nickname,
+            user_pw,
+            user_birth_date,
+            user_phone,
+            user_email,
+            user_regist_date,
+            deleted_at,
+            user_status,
+            user_role
+        FROM user
+        WHERE user_email = #{userEmail}
+          AND user_status = 'active'
+    </select>
+
     <!-- 5. 회원 탈퇴 (soft delete) -->
     <update id="softDeleteUser">
         UPDATE user

--- a/BookSpace/frontend/src/api/userApi.js
+++ b/BookSpace/frontend/src/api/userApi.js
@@ -43,8 +43,18 @@ export const verifyUserApi = (payload) => {
   return httpClient.post("/users/verify", payload).then((res) => res.data);
 };
 
-// 11. 비밀번호 재설정
+// 11. 비밀번호 재설정 (코드 인증 후)
 export const resetPasswordApi = (payload) => {
   // payload: { userLoginId, userEmail, newPassword }
-  return httpClient.post("/users/reset-password", payload).then((res) => res.data);
+  return httpClient
+    .post("/users/reset-password", payload)
+    .then((res) => res.data);
+};
+
+// 12. 비밀번호 재설정 (링크 토큰 사용)
+export const resetPasswordByTokenApi = (payload) => {
+  // payload: { token, newPassword }
+  return httpClient
+    .post("/users/reset-password-by-token", payload)
+    .then((res) => res.data);
 };

--- a/BookSpace/frontend/src/components/ai-recommend/ChatInput.vue
+++ b/BookSpace/frontend/src/components/ai-recommend/ChatInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="chat-input-container">
-    <div class="flex items-end gap-3 p-4">
+    <div class="flex items-end gap-2 p-4 border-t border-border">
       <!-- 입력 필드 -->
       <div class="flex-1">
         <textarea
@@ -13,7 +13,7 @@
           :placeholder="placeholder"
           :disabled="disabled"
           rows="1"
-          class="w-full resize-none rounded-2xl border-2 border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-5 py-3 text-sm text-card-foreground outline-none transition-all duration-200 focus:border-blue-400 dark:focus:border-blue-500 focus:ring-2 focus:ring-blue-100 dark:focus:ring-blue-900/30 disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-muted-foreground min-h-[44px] max-h-32 overflow-y-auto scrollbar-hide shadow-sm"
+          class="w-full resize-none rounded-3xl border border-input bg-accent px-5 py-3 text-sm text-foreground outline-none transition focus:border-yellow-400 focus:ring-2 focus:ring-yellow-400/20 disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-muted-foreground min-h-[44px] max-h-32 overflow-y-auto scrollbar-hide"
         ></textarea>
       </div>
 
@@ -21,11 +21,11 @@
       <button
         @click="handleSend"
         :disabled="!canSend"
-        class="flex-shrink-0 w-11 h-11 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed flex items-center justify-center transition-all duration-200 shadow-md hover:shadow-lg hover:scale-105"
+        class="flex-shrink-0 w-10 h-10 rounded-full bg-yellow-400 hover:bg-yellow-500 disabled:bg-gray-300 disabled:cursor-not-allowed flex items-center justify-center transition shadow-sm"
       >
         <svg
-          class="w-5 h-5 text-white"
-          :class="{ 'text-gray-100': !canSend }"
+          class="w-4 h-4 text-gray-800"
+          :class="{ 'text-gray-500': !canSend }"
           fill="none"
           stroke="currentColor"
           stroke-width="2"
@@ -113,4 +113,23 @@ defineExpose({
 </script>
 
 <style scoped>
+/* Hide scrollbar but keep functionality */
+.scrollbar-hide {
+  -ms-overflow-style: none !important;
+  scrollbar-width: none !important;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+}
+
+.scrollbar-hide::-webkit-scrollbar-track {
+  display: none !important;
+}
+
+.scrollbar-hide::-webkit-scrollbar-thumb {
+  display: none !important;
+}
 </style>

--- a/BookSpace/frontend/src/components/ai-recommend/ChatMessage.vue
+++ b/BookSpace/frontend/src/components/ai-recommend/ChatMessage.vue
@@ -16,20 +16,16 @@
       <!-- Message Content -->
       <div class="flex-1">
         <div
-          class="relative bg-gradient-to-br from-blue-50 to-purple-50 dark:from-slate-800 dark:to-slate-700 border border-blue-200 dark:border-blue-500/30 rounded-2xl rounded-tl-sm px-5 py-4 shadow-sm"
+          class="bg-white border border-gray-200 rounded-2xl rounded-tl-sm px-5 py-4 shadow-sm"
         >
-          <!-- AI 배지 -->
-          <span class="absolute -top-2 left-3 px-3 py-2 bg-gradient-to-r from-blue-500 to-purple-600 text-white text-xs font-medium rounded-full">
-            책봇
-          </span>
-          <p class="text-sm text-card-foreground leading-relaxed whitespace-pre-wrap mt-1">
+          <p class="text-sm text-gray-800 leading-relaxed whitespace-pre-wrap">
             {{ message.content }}
           </p>
 
           <!-- Book Recommendations List (if exists) -->
           <div
             v-if="
-              message.bookRecommendations &&  
+              message.bookRecommendations &&
               message.bookRecommendations.length > 0
             "
             class="mt-4 space-y-3"
@@ -37,7 +33,7 @@
             <div
               v-for="(book, index) in message.bookRecommendations"
               :key="index"
-              class="flex gap-4 cursor-pointer hover:bg-muted p-3 rounded-lg transition"
+              class="flex gap-4 cursor-pointer hover:bg-gray-50 p-3 rounded-lg transition"
               @click="handleBookClick(book)"
             >
               <!-- Book Cover -->
@@ -49,19 +45,19 @@
 
               <!-- Book Info -->
               <div class="flex-1 min-w-0">
-                <h3 class="text-sm font-bold text-card-foreground line-clamp-2 mb-1">
+                <h3 class="text-sm font-bold text-gray-900 line-clamp-2 mb-1">
                   {{ book.title }}
                 </h3>
-                <p class="text-xs text-muted-foreground mb-2">{{ book.author }}</p>
+                <p class="text-xs text-gray-600 mb-2">{{ book.author }}</p>
 
                 <!-- Publisher and Genre -->
-                <p class="text-xs text-muted-foreground mb-2">
+                <p class="text-xs text-gray-500 mb-2">
                   {{ book.publisher || "문학동네" }} •
                   {{ book.metadata || "소설" }}
                 </p>
 
                 <!-- Rating -->
-                <div class="flex items-center gap-1 text-xs text-muted-foreground">
+                <div class="flex items-center gap-1 text-xs text-gray-500">
                   <svg
                     class="w-3 h-3 text-yellow-400 fill-current"
                     viewBox="0 0 20 20"
@@ -80,7 +76,7 @@
             </div>
           </div>
         </div>
-        <div class="text-xs text-muted-foreground mt-1 ml-1">
+        <div class="text-xs text-gray-400 mt-1 ml-1">
           {{ formatTime(message.timestamp) }}
         </div>
       </div>
@@ -90,13 +86,13 @@
     <div v-else class="flex justify-end">
       <div class="max-w-[85%]">
         <div
-          class="bg-gradient-to-br from-blue-500 to-purple-600 rounded-2xl rounded-tr-sm px-5 py-4 shadow-sm"
+          class="bg-yellow-400 rounded-2xl rounded-tr-sm px-5 py-4 shadow-sm"
         >
-          <p class="text-sm text-white leading-relaxed whitespace-pre-wrap">
+          <p class="text-sm text-gray-900 leading-relaxed whitespace-pre-wrap">
             {{ message.content }}
           </p>
         </div>
-        <div class="text-xs text-muted-foreground mt-1 mr-1 text-right">
+        <div class="text-xs text-gray-400 mt-1 mr-1 text-right">
           {{ formatTime(message.timestamp) }}
         </div>
       </div>
@@ -159,5 +155,13 @@ const formatTime = (date) => {
   }
 }
 
-/* 스크롤바 스타일은 이제 global.css에서 전역으로 처리됩니다 */
+/* Hide scrollbar but keep functionality */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
 </style>

--- a/BookSpace/frontend/src/components/ai-recommend/SuggestedQuestions.vue
+++ b/BookSpace/frontend/src/components/ai-recommend/SuggestedQuestions.vue
@@ -5,7 +5,7 @@
         v-for="(question, index) in questions"
         :key="index"
         @click="$emit('select', question)"
-        class="flex-shrink-0 px-4 py-2.5 bg-gradient-to-r from-blue-500/10 to-purple-500/10 dark:from-blue-500/20 dark:to-purple-500/20 border border-blue-300 dark:border-blue-500/50 rounded-full text-sm text-blue-600 dark:text-blue-400 font-medium hover:from-blue-500 hover:to-purple-600 hover:text-white hover:border-transparent transition-all duration-200 shadow-sm hover:shadow-md whitespace-nowrap"
+        class="flex-shrink-0 px-4 py-2 bg-card border border-border rounded-full text-sm text-foreground hover:bg-accent hover:border-border transition shadow-sm whitespace-nowrap"
       >
         {{ question }}
       </button>
@@ -49,4 +49,23 @@ defineEmits(["select"]);
   }
 }
 
+/* Hide scrollbar but keep functionality */
+.scrollbar-hide {
+  -ms-overflow-style: none !important;
+  scrollbar-width: none !important;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+}
+
+.scrollbar-hide::-webkit-scrollbar-track {
+  display: none !important;
+}
+
+.scrollbar-hide::-webkit-scrollbar-thumb {
+  display: none !important;
+}
 </style>

--- a/BookSpace/frontend/src/components/community/PostCard.vue
+++ b/BookSpace/frontend/src/components/community/PostCard.vue
@@ -77,7 +77,7 @@
       </div>
     </div>
     <!-- 오른쪽: 책 정보 -->
-    <div class="flex flex-col items-center text-center w-28">
+    <div class="flex flex-col items-center text-center w-28 flex-shrink-0">
       <img
         :src="post.bookImageUrl || defaultBook"
         class="object-cover w-24 h-32 rounded"
@@ -147,7 +147,7 @@ const toggleLikeMutation = useMutation({
     await queryClient.cancelQueries({ queryKey: ["posts", "latest"] });
     await queryClient.cancelQueries({ queryKey: ["my-posts"] });
     await queryClient.cancelQueries({ queryKey: ["post", props.post.postId] });
-    
+
     const previous = { liked: isLiked.value, likeCount: likeCount.value };
 
     // 목록 캐시 낙관적 업데이트
@@ -158,7 +158,10 @@ const toggleLikeMutation = useMutation({
       const updatedPages = cache.pages.map((page) => {
         const updatedPosts = page.posts?.map((p) => {
           if (String(p.postId) !== String(props.post.postId)) return p;
-          const nextCount = Math.max(0, (p.likeCount ?? 0) + (nextLiked ? 1 : -1));
+          const nextCount = Math.max(
+            0,
+            (p.likeCount ?? 0) + (nextLiked ? 1 : -1)
+          );
           return { ...p, liked: nextLiked, likeCount: nextCount };
         });
         return { ...page, posts: updatedPosts };
@@ -173,7 +176,10 @@ const toggleLikeMutation = useMutation({
       if (!Array.isArray(cache)) return cache;
       const updated = cache.map((p) => {
         if (String(p.postId) !== String(props.post.postId)) return p;
-        const nextCount = Math.max(0, (p.likeCount ?? 0) + (nextLiked ? 1 : -1));
+        const nextCount = Math.max(
+          0,
+          (p.likeCount ?? 0) + (nextLiked ? 1 : -1)
+        );
         return { ...p, liked: nextLiked, likeCount: nextCount };
       });
       queryClient.setQueryData(["my-posts"], updated);
@@ -184,11 +190,14 @@ const toggleLikeMutation = useMutation({
     const updateDetailCache = () => {
       const cache = queryClient.getQueryData(["post", props.post.postId]);
       if (!cache) return cache;
-      const nextCount = Math.max(0, (cache.likeCount ?? 0) + (nextLiked ? 1 : -1));
-      queryClient.setQueryData(["post", props.post.postId], { 
-        ...cache, 
-        liked: nextLiked, 
-        likeCount: nextCount 
+      const nextCount = Math.max(
+        0,
+        (cache.likeCount ?? 0) + (nextLiked ? 1 : -1)
+      );
+      queryClient.setQueryData(["post", props.post.postId], {
+        ...cache,
+        liked: nextLiked,
+        likeCount: nextCount,
       });
       return cache;
     };
@@ -198,7 +207,13 @@ const toggleLikeMutation = useMutation({
     const previousMyPosts = updateMyPosts();
     const previousDetail = updateDetailCache();
 
-    return { previous, previousPosts, previousLatest, previousMyPosts, previousDetail };
+    return {
+      previous,
+      previousPosts,
+      previousLatest,
+      previousMyPosts,
+      previousDetail,
+    };
   },
   onSuccess: async (data, nextLiked) => {
     console.log("[LIKE] Mutation succeeded. Updating with server data.");

--- a/BookSpace/frontend/src/components/ui/ValidatedInput.vue
+++ b/BookSpace/frontend/src/components/ui/ValidatedInput.vue
@@ -48,25 +48,62 @@
         tabindex="-1"
       >
         <!-- 눈 열림 아이콘 (비밀번호 보이는 상태) -->
-        <svg v-if="showPassword" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        <svg
+          v-if="showPassword"
+          class="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+          />
         </svg>
         <!-- 눈 닫힘 아이콘 (비밀번호 숨김 상태) -->
-        <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+        <svg
+          v-else
+          class="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+          />
         </svg>
       </button>
     </div>
 
     <!-- 에러 메시지 영역 (고정 높이로 레이아웃 유지) -->
     <div class="h-6 mt-1">
-      <p 
-        v-if="error" 
+      <p
+        v-if="error"
         class="flex items-center gap-1.5 text-sm text-red-500 dark:text-red-400 font-medium"
       >
-        <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        <svg
+          class="w-4 h-4 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
         </svg>
         {{ errorMessage }}
       </p>
@@ -144,7 +181,6 @@ const error = computed(() => props.v$.$error);
 const errorMessage = computed(() => {
   if (!error.value) return "";
 
-
   // 1) 중복(unique) 에러 (아이디 / 이메일 / 닉네임 등)
   if (props.v$.unique?.$invalid) {
     if (props.field === "loginId") {
@@ -157,8 +193,7 @@ const errorMessage = computed(() => {
       return "이미 사용 중인 닉네임입니다.";
     }
     return "이미 사용 중인 값입니다.";
-  }  
-
+  }
 
   // required
   if (props.v$.required?.$invalid) {
@@ -170,9 +205,17 @@ const errorMessage = computed(() => {
     return "유효한 이메일을 입력하세요.";
   }
 
-  // password (minLength)
-  if (props.type === "password" && props.v$.minLength?.$invalid) {
-    return "비밀번호는 최소 8자 이상이어야 합니다.";
+  // password (passwordFormat이 있으면 우선, 없으면 minLength)
+  if (props.type === "password") {
+    if (props.v$.passwordFormat?.$invalid) {
+      return (
+        props.v$.passwordFormat.$message ||
+        "비밀번호는 8자 이상이어야 합니다. (숫자, 특수문자, 영문 포함)"
+      );
+    }
+    if (props.v$.minLength?.$invalid && !props.v$.passwordFormat) {
+      return "비밀번호는 8자 이상이어야 합니다. (숫자, 특수문자, 영문 포함)";
+    }
   }
 
   // password(sameAs)
@@ -251,7 +294,7 @@ const inputClasses = computed(() => {
 
   // 추가 클래스
   if (props.class) base.push(props.class);
-  
+
   return base;
 });
 

--- a/BookSpace/frontend/src/router/index.js
+++ b/BookSpace/frontend/src/router/index.js
@@ -80,7 +80,11 @@ const router = createRouter({
     //  layout(헤더, 푸터) 적용 없는 페이지
     { path: "/signin", name: "signin", component: SignInView },
     { path: "/signup", name: "signup", component: SignupView },
-    { path: "/forgot-password", name: "forgotPassword", component: ForgotPasswordView },
+    {
+      path: "/forgot-password",
+      name: "forgotPassword",
+      component: ForgotPasswordView,
+    },
   ],
 });
 

--- a/BookSpace/frontend/src/views/AiRecommendView.vue
+++ b/BookSpace/frontend/src/views/AiRecommendView.vue
@@ -3,10 +3,10 @@
     <!-- Header -->
     <header class="bg-background border-b border-border">
       <div
-        class="flex items-center justify-between px-4 h-full max-w-2xl mx-auto"
+        class="flex items-center justify-between px-4 py-3 max-w-2xl mx-auto"
       >
         <BackButton />
-        <h1 class="text-lg font-semibold text-foreground">AI 책봇</h1>
+        <h1 class="text-lg font-semibold text-foreground">AI 도서 추천</h1>
         <div class="w-9"></div>
       </div>
     </header>
@@ -105,7 +105,7 @@
 
 <script setup>
 import { ref, nextTick, onMounted, onUpdated, watch } from "vue";
-import { useRouter, useRoute } from "vue-router";
+import { useRouter } from "vue-router";
 import ChatMessage from "@/components/ai-recommend/ChatMessage.vue";
 import ChatInput from "@/components/ai-recommend/ChatInput.vue";
 import SuggestedQuestions from "@/components/ai-recommend/SuggestedQuestions.vue";
@@ -116,9 +116,7 @@ import { getAiRecommendation } from "@/api/aiRecommendationApi";
 import { useToast } from "@/composables/useToast";
 
 const router = useRouter();
-const route = useRoute();
 const { toast } = useToast();
-const chatInputRef = ref(null);
 
 // State
 const messages = ref([]);
@@ -150,9 +148,9 @@ const transformApiResponse = (apiResponse) => {
   let content = "";
 
   // 감정 분석 메시지와 위로 메시지 조합
-  // if (apiResponse.userEmotion) {
-  //   content += `${apiResponse.userEmotion}\n\n`;
-  // }
+  if (apiResponse.userEmotion) {
+    content += `${apiResponse.userEmotion}\n\n`;
+  }
 
   if (apiResponse.comfortMessage) {
     content += apiResponse.comfortMessage;
@@ -282,15 +280,12 @@ onMounted(() => {
     updateFooterHeight();
   });
 
-  // URL에서 prompt query 파라미터가 있으면 자동으로 메시지 전송
-  const promptFromQuery = route.query.prompt;
-  if (promptFromQuery && typeof promptFromQuery === 'string' && promptFromQuery.trim()) {
-    // 컴포넌트가 완전히 준비된 후 메시지 전송 (100ms 딜레이)
-    setTimeout(() => {
-      isInputActive.value = true;
-      handleSendMessage(promptFromQuery.trim());
-    }, 100);
-  }
+  // Optional: Add initial AI greeting
+  // messages.value.push({
+  //   type: 'ai',
+  //   content: '안녕하세요! 어떤 책을 찾고 계신가요?',
+  //   timestamp: new Date()
+  // })
 });
 
 onUpdated(() => {

--- a/BookSpace/frontend/src/views/ForgotPasswordView.vue
+++ b/BookSpace/frontend/src/views/ForgotPasswordView.vue
@@ -42,10 +42,67 @@
         </Button>
       </form>
 
-      <!-- Step 2: 비밀번호 재설정 -->
-      <form v-else-if="step === 2" @submit.prevent="resetPassword" class="space-y-4">
+      <!-- Step 2: 이메일 인증 -->
+      <form
+        v-else-if="step === 2"
+        @submit.prevent="verifyEmailCode"
+        class="space-y-4"
+      >
         <p class="text-sm text-center text-green-600 mb-4">
-          ✓ 본인 확인이 완료되었습니다. 새 비밀번호를 입력해주세요.
+          ✓ 본인 확인이 완료되었습니다. 이메일로 발송된 인증 코드를
+          입력해주세요.
+        </p>
+
+        <div class="space-y-2">
+          <div class="flex gap-2 items-start">
+            <div class="flex-1">
+              <ValidatedInput
+                v-model="verificationCode"
+                :v$="v$Email.verificationCode"
+                type="text"
+                placeholder="인증 코드 6자리"
+                maxlength="6"
+                @input="handleCodeInput"
+              />
+            </div>
+            <Button
+              type="button"
+              @click="sendVerificationCode"
+              :loading="isSendingCode"
+              :disabled="isSendingCode || codeResendCooldown > 0"
+              variant="outline"
+              class="whitespace-nowrap h-[48px]"
+            >
+              {{
+                codeResendCooldown > 0 ? `${codeResendCooldown}초` : "재발송"
+              }}
+            </Button>
+          </div>
+          <p class="text-xs text-muted-foreground">
+            {{ email }}로 인증 코드를 발송했습니다. (유효시간: 5분)
+          </p>
+        </div>
+
+        <Button
+          type="submit"
+          :loading="isSubmitting"
+          :disabled="v$Email.$invalid"
+          class="w-full mt-6"
+        >
+          인증 확인
+        </Button>
+      </form>
+
+      <!-- Step 3: 비밀번호 재설정 -->
+      <form
+        v-else-if="step === 3"
+        @submit.prevent="
+          route.query.token ? resetPasswordByToken() : resetPassword()
+        "
+        class="space-y-4"
+      >
+        <p class="text-sm text-center text-green-600 mb-4">
+          ✓ 이메일 인증이 완료되었습니다. 새 비밀번호를 입력해주세요.
         </p>
 
         <ValidatedInput
@@ -72,20 +129,18 @@
         </Button>
       </form>
 
-      <!-- Step 3: 완료 -->
+      <!-- Step 4: 완료 -->
       <div v-else class="text-center space-y-4">
         <div class="text-green-600 text-5xl mb-4">✓</div>
         <h2 class="text-xl font-bold">비밀번호가 변경되었습니다</h2>
-        <p class="text-muted-foreground">
-          새 비밀번호로 로그인해주세요.
-        </p>
+        <p class="text-muted-foreground">새 비밀번호로 로그인해주세요.</p>
         <RouterLink to="/signin">
           <Button class="w-full mt-4">로그인하기</Button>
         </RouterLink>
       </div>
 
-      <!-- 로그인 이동 (Step 1, 2에서만) -->
-      <p v-if="step < 3" class="mt-6 text-sm text-center text-muted-foreground">
+      <!-- 로그인 이동 (Step 1, 2, 3에서만) -->
+      <p v-if="step < 4" class="mt-6 text-sm text-center text-muted-foreground">
         비밀번호가 기억나셨나요?
         <RouterLink
           to="/signin"
@@ -99,23 +154,44 @@
 </template>
 
 <script setup>
-import { ref, computed } from "vue";
-import { RouterLink } from "vue-router";
+import { ref, computed, onUnmounted, onMounted } from "vue";
+import { RouterLink, useRoute, useRouter } from "vue-router";
 import AppLogo from "@/components/common/AppLogo.vue";
 import ValidatedInput from "@/components/ui/ValidatedInput.vue";
 import Button from "@/components/ui/Button.vue";
 import useVuelidate from "@vuelidate/core";
-import { required, email as emailValidator, minLength, sameAs } from "@vuelidate/validators";
-import { verifyUserApi, resetPasswordApi } from "@/api/userApi";
+import {
+  required,
+  email as emailValidator,
+  minLength,
+  sameAs,
+} from "@vuelidate/validators";
+import {
+  verifyUserApi,
+  resetPasswordApi,
+  resetPasswordByTokenApi,
+} from "@/api/userApi";
+import { sendVerificationCodeApi, verifyCodeApi } from "@/api/emailApi";
+import { useToast } from "@/composables/useToast";
 
-// 단계 관리 (1: 본인확인, 2: 비밀번호 변경, 3: 완료)
+const { toast } = useToast();
+const route = useRoute();
+const router = useRouter();
+
+// 단계 관리 (1: 본인확인, 2: 이메일 인증, 3: 비밀번호 변경, 4: 완료)
 const step = ref(1);
 
 // Step 1: 본인 확인
 const loginId = ref("");
 const email = ref("");
 
-// Step 2: 비밀번호 재설정
+// Step 2: 이메일 인증
+const verificationCode = ref("");
+const isSendingCode = ref(false);
+const codeResendCooldown = ref(0);
+let cooldownTimer = null;
+
+// Step 3: 비밀번호 재설정
 const newPassword = ref("");
 const confirmPassword = ref("");
 
@@ -128,15 +204,24 @@ const rules = {
 };
 const v$ = useVuelidate(rules, { loginId, email });
 
-// Step 2 유효성 검사 규칙
-const rulesReset = computed(() => ({
-  newPassword: { 
-    required, 
-    minLength: minLength(8) 
+// Step 2 유효성 검사 규칙 (이메일 인증)
+const rulesEmail = {
+  verificationCode: {
+    required,
+    minLength: minLength(6),
   },
-  confirmPassword: { 
-    required, 
-    sameAs: sameAs(newPassword) 
+};
+const v$Email = useVuelidate(rulesEmail, { verificationCode });
+
+// Step 3 유효성 검사 규칙 (비밀번호 재설정)
+const rulesReset = computed(() => ({
+  newPassword: {
+    required,
+    minLength: minLength(8),
+  },
+  confirmPassword: {
+    required,
+    sameAs: sameAs(newPassword),
   },
 }));
 const v$Reset = useVuelidate(rulesReset, { newPassword, confirmPassword });
@@ -153,18 +238,121 @@ const verifyUser = async () => {
     });
 
     if (result.verified) {
-      step.value = 2;
+      // 재설정 링크가 발송된 경우 (가입 시 이메일 인증 완료된 사용자)
+      if (result.isLinkSent && result.resetLink) {
+        toast({
+          title: "재설정 링크 발송",
+          description: "이메일로 비밀번호 재설정 링크를 발송했습니다.",
+        });
+        step.value = 3; // 링크 발송 시 이메일 인증 단계 건너뛰기
+      } else {
+        // 인증 코드 발송 (가입 시 이메일 인증 안 한 사용자)
+        await sendVerificationCode();
+        step.value = 2;
+      }
     } else {
-      alert("입력하신 정보와 일치하는 계정을 찾을 수 없습니다.");
+      toast({
+        title: "본인 확인 실패",
+        description: "입력하신 정보와 일치하는 계정을 찾을 수 없습니다.",
+        variant: "destructive",
+      });
     }
   } catch (err) {
-    alert(err.response?.data?.message || "본인 확인에 실패했습니다.");
+    toast({
+      title: "본인 확인 실패",
+      description: err.response?.data?.message || "본인 확인에 실패했습니다.",
+      variant: "destructive",
+    });
   } finally {
     isSubmitting.value = false;
   }
 };
 
-// 비밀번호 재설정
+// 이메일 인증 코드 발송
+const sendVerificationCode = async () => {
+  if (isSendingCode.value) return;
+  isSendingCode.value = true;
+
+  try {
+    const result = await sendVerificationCodeApi(email.value);
+
+    if (result.success) {
+      toast({
+        title: "인증 코드 발송",
+        description: "이메일로 인증 코드를 발송했습니다.",
+      });
+
+      // 재발송 쿨다운 시작 (60초)
+      codeResendCooldown.value = 60;
+      if (cooldownTimer) clearInterval(cooldownTimer);
+      cooldownTimer = setInterval(() => {
+        codeResendCooldown.value--;
+        if (codeResendCooldown.value <= 0) {
+          clearInterval(cooldownTimer);
+          cooldownTimer = null;
+        }
+      }, 1000);
+    } else {
+      toast({
+        title: "발송 실패",
+        description: result.message || "인증 코드 발송에 실패했습니다.",
+        variant: "destructive",
+      });
+    }
+  } catch (err) {
+    toast({
+      title: "발송 실패",
+      description:
+        err.response?.data?.message || "인증 코드 발송에 실패했습니다.",
+      variant: "destructive",
+    });
+  } finally {
+    isSendingCode.value = false;
+  }
+};
+
+// 인증 코드 입력 핸들러 (숫자만 입력)
+const handleCodeInput = (event) => {
+  const value = event.target.value.replace(/[^0-9]/g, "");
+  verificationCode.value = value;
+  event.target.value = value;
+};
+
+// 이메일 인증 코드 검증
+const verifyEmailCode = async () => {
+  if (isSubmitting.value) return;
+  isSubmitting.value = true;
+
+  try {
+    const result = await verifyCodeApi(email.value, verificationCode.value);
+
+    if (result.success) {
+      toast({
+        title: "인증 완료",
+        description: "이메일 인증이 완료되었습니다.",
+      });
+      step.value = 3;
+    } else {
+      toast({
+        title: "인증 실패",
+        description:
+          result.message || "인증 코드가 일치하지 않거나 만료되었습니다.",
+        variant: "destructive",
+      });
+    }
+  } catch (err) {
+    toast({
+      title: "인증 실패",
+      description:
+        err.response?.data?.message || "인증 코드 검증에 실패했습니다.",
+      variant: "destructive",
+    });
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+
+// 비밀번호 재설정 (코드 인증 후)
 const resetPassword = async () => {
   if (isSubmitting.value) return;
   isSubmitting.value = true;
@@ -176,12 +364,72 @@ const resetPassword = async () => {
       newPassword: newPassword.value,
     });
 
-    step.value = 3;
+    step.value = 4;
   } catch (err) {
-    alert(err.response?.data?.message || "비밀번호 변경에 실패했습니다.");
+    toast({
+      title: "비밀번호 변경 실패",
+      description:
+        err.response?.data?.message || "비밀번호 변경에 실패했습니다.",
+      variant: "destructive",
+    });
   } finally {
     isSubmitting.value = false;
   }
 };
-</script>
 
+// 비밀번호 재설정 (토큰 사용 - 링크 클릭 시)
+const resetPasswordByToken = async () => {
+  const token = route.query.token;
+  if (!token) {
+    toast({
+      title: "유효하지 않은 링크",
+      description: "재설정 링크가 올바르지 않습니다.",
+      variant: "destructive",
+    });
+    return;
+  }
+
+  if (isSubmitting.value) return;
+  isSubmitting.value = true;
+
+  try {
+    await resetPasswordByTokenApi({
+      token: token,
+      newPassword: newPassword.value,
+    });
+
+    // 토큰 제거하고 완료 페이지로
+    router.replace({ path: route.path, query: {} });
+    step.value = 4;
+  } catch (err) {
+    toast({
+      title: "비밀번호 변경 실패",
+      description:
+        err.response?.data?.message || "비밀번호 변경에 실패했습니다.",
+      variant: "destructive",
+    });
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+
+// URL에 토큰이 있는 경우 처리
+onMounted(() => {
+  const token = route.query.token;
+  if (token) {
+    // 토큰이 있으면 바로 비밀번호 재설정 단계로
+    step.value = 3;
+    toast({
+      title: "비밀번호 재설정",
+      description: "새 비밀번호를 입력해주세요.",
+    });
+  }
+});
+
+// 컴포넌트 언마운트 시 타이머 정리
+onUnmounted(() => {
+  if (cooldownTimer) {
+    clearInterval(cooldownTimer);
+  }
+});
+</script>

--- a/BookSpace/frontend/src/views/SignupView.vue
+++ b/BookSpace/frontend/src/views/SignupView.vue
@@ -1,6 +1,7 @@
 <!-- 
 # Sign Up View
-- <ValidatedInput>: 폼 유효성 검사 & 에러 메세지 포함 컴포넌트 (src/components/ui/ValidatedInput.vue)
+- 회원가입 폼 뷰 컴포넌트
+- ValidatedInput: 폼 유효성 검사 & 에러 메세지 포함 컴포넌트 (src/components/ui/ValidatedInput.vue)
 - 검사 시점: 각 인풋에서 포커스가 벗어날 때 검사 (blur) 
 -->
 <template>
@@ -8,7 +9,7 @@
     class="flex flex-col items-center justify-center min-h-screen px-4 bg-gradient-to-b from-background to-muted/20"
   >
     <div class="w-full max-w-md">
-      <!-- 로고 & 로그인 -->
+      <!-- 로고 & 제목 -->
       <div class="mb-8 text-center">
         <AppLogo size="lg" />
         <h1 class="text-3xl font-bold">회원가입</h1>
@@ -53,53 +54,12 @@
         />
 
         <!-- 이메일 + 인증 -->
-        <div class="space-y-2">
-          <!-- 이메일 입력 + 인증번호 받기 버튼 -->
-          <div class="flex gap-2">
-            <div class="flex-1">
-              <ValidatedInput
-                v-model="email"
-                :v$="v$.email"
-                type="email"
-                field="email"
-                placeholder="이메일"
-                :disabled="isEmailVerified"
-              />
-            </div>
-            <button
-              type="button"
-              @click="sendVerificationCode"
-              :disabled="!isEmailValid || isSendingCode || isEmailVerified"
-              class="px-4 py-3 text-sm font-medium text-white bg-blue-500 rounded-xl hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
-            >
-              {{ isSendingCode ? '발송 중...' : isEmailVerified ? '인증완료' : '인증번호 받기' }}
-            </button>
-          </div>
-
-          <!-- 인증번호 입력 (코드 발송 후 표시) -->
-          <div v-if="isCodeSent && !isEmailVerified" class="flex gap-2">
-            <input
-              v-model="verificationCode"
-              type="text"
-              maxlength="6"
-              placeholder="인증번호 6자리 입력"
-              class="flex-1 px-4 py-3 text-sm border-2 border-gray-200 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 outline-none focus:border-blue-500"
-            />
-            <button
-              type="button"
-              @click="verifyCode"
-              :disabled="verificationCode.length !== 6 || isVerifying"
-              class="px-4 py-3 text-sm font-medium text-white bg-emerald-500 rounded-xl hover:bg-emerald-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
-            >
-              {{ isVerifying ? '확인 중...' : '확인' }}
-            </button>
-          </div>
-
-          <!-- 인증 상태 메시지 -->
-          <p v-if="emailVerificationMessage" :class="isEmailVerified ? 'text-emerald-500' : 'text-blue-500'" class="text-sm">
-            {{ emailVerificationMessage }}
-          </p>
-        </div>
+        <EmailVerificationInput
+          :email="email"
+          :v$Email="v$.email"
+          @update:email="email = $event"
+          @verified="handleEmailVerified"
+        />
 
         <!-- 닉네임 -->
         <ValidatedInput
@@ -111,20 +71,10 @@
         />
 
         <!-- 전화번호 -->
-        <ValidatedInput
-          v-model="phone"
-          :v$="v$.phone"
-          type="text"
-          placeholder="전화번호 (e.g.010-1234-5678)"
-        />
+        <PhoneNumberInput v-model="phone" :v$Phone="v$.phone" />
 
         <!-- 생년월일 -->
-        <ValidatedInput
-          v-model="birth"
-          :v$="v$.birth"
-          type="text"
-          placeholder="생년월일 (e.g.2025-12-17)"
-        />
+        <BirthDateInput v-model="birth" :v$Birth="v$.birth" />
 
         <!-- 회원가입 버튼 -->
         <Button
@@ -152,129 +102,17 @@
 </template>
 
 <script setup>
-// 상태
-const loginId = ref("");
-const email = ref("");
-const password = ref("");
-const confirmPassword = ref("");
-const name = ref("");
-const nickname = ref("");
-const phone = ref("");
-const birth = ref("");
-const isSubmitting = ref(false);
+import { RouterLink } from "vue-router";
+import ValidatedInput from "@/components/ui/ValidatedInput.vue";
+import Button from "@/components/ui/Button.vue";
+import AppLogo from "@/components/common/AppLogo.vue";
+import EmailVerificationInput from "@/components/signup/EmailVerificationInput.vue";
+import PhoneNumberInput from "@/components/signup/PhoneNumberInput.vue";
+import BirthDateInput from "@/components/signup/BirthDateInput.vue";
+import { useSignupForm } from "@/composables/signup/useSignupForm";
 
-// 이메일 인증 상태
-const verificationCode = ref("");
-const isCodeSent = ref(false);
-const isSendingCode = ref(false);
-const isVerifying = ref(false);
-const isEmailVerified = ref(false);
-const emailVerificationMessage = ref("");
-
-const userStore = useUserStore();
-const router = useRouter();
-
-// 이메일 유효성 검사 (인증번호 받기 버튼 활성화용)
-// 반드시 @ 뒤에 도메인이 있어야 함 (예: user@gmail.com)
-const isEmailValid = computed(() => {
-  const emailRegex = /^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
-  return emailRegex.test(email.value);
-});
-
-// 인증번호 발송
-const sendVerificationCode = async () => {
-  if (isSendingCode.value || !isEmailValid.value) return;
-
-  isSendingCode.value = true;
-  emailVerificationMessage.value = "";
-
-  try {
-    const result = await sendVerificationCodeApi(email.value);
-    if (result.success) {
-      isCodeSent.value = true;
-      emailVerificationMessage.value = "인증번호가 이메일로 발송되었습니다. (5분 내 입력)";
-    } else {
-      emailVerificationMessage.value = result.message;
-    }
-  } catch (err) {
-    emailVerificationMessage.value = err.response?.data?.message || "인증번호 발송에 실패했습니다.";
-  } finally {
-    isSendingCode.value = false;
-  }
-};
-
-// 인증번호 확인
-const verifyCode = async () => {
-  if (isVerifying.value || verificationCode.value.length !== 6) return;
-
-  isVerifying.value = true;
-
-  try {
-    const result = await verifyCodeApi(email.value, verificationCode.value);
-    if (result.success) {
-      isEmailVerified.value = true;
-      emailVerificationMessage.value = "✓ 이메일 인증이 완료되었습니다.";
-    } else {
-      emailVerificationMessage.value = result.message;
-    }
-  } catch (err) {
-    emailVerificationMessage.value = err.response?.data?.message || "인증번호가 일치하지 않습니다.";
-  } finally {
-    isVerifying.value = false;
-  }
-};
-
-// 중복 체크용 함수 정의
-const dupCheck = (type) =>
-    helpers.withAsync(async (value) => {
-      if(!value) return true;
-      
-      // 이메일 타입인 경우, 형식이 유효할 때만 중복 체크
-      if (type === "email") {
-        const emailRegex = /^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
-        if (!emailRegex.test(value)) return true; // 형식 검사 먼저 통과 필요
-      }
-      
-      try {
-        return await userStore.checkDuplicate(type, value);
-      } catch {
-        return true;
-      }
-    });
-
-// vuelidate 규칙 정의
-const rules = {
-  loginId: { 
-    required, 
-    minLength: minLength(4),
-    unique: dupCheck("loginId"),
-  },
-  email: { 
-    required, 
-    email: emailValidator,
-    unique: dupCheck("email")
-  },
-  password: { required, minLength: minLength(8) },
-  confirmPassword: { required, sameAs: sameAs(password) },
-  name: { required },
-  nickname: { 
-    required,
-    unique: dupCheck("nickname")
-  },
-  phone: {
-    //000-0000-0000
-    phoneFormat: helpers.regex(/^\d{3}-\d{4}-\d{4}$/),
-    $autoDirty: true,
-  },
-  birth: {
-    // 0000-00-00
-    birthFormat: helpers.regex(/^\d{4}-\d{2}-\d{2}$/),
-    $autoDirty: true,
-  },
-};
-
-//vuelidate 인스턴스 생성
-const v$ = useVuelidate(rules, {
+// 회원가입 폼 로직
+const {
   loginId,
   email,
   password,
@@ -283,73 +121,15 @@ const v$ = useVuelidate(rules, {
   nickname,
   phone,
   birth,
-});
+  isSubmitting,
+  isEmailVerified,
+  v$,
+  signup,
+  setIsEmailVerified,
+} = useSignupForm();
 
-// 회원가입 확인
-const signup = async () => {
-  
-  // 이미 요청 중이면 또 요청 안보내기
-  if (isSubmitting.value) return;
-
-  // 이메일 인증 확인
-  if (!isEmailVerified.value) {
-    alert("이메일 인증을 완료해주세요.");
-    return;
-  }
-
-  // 유효성 검사
-  const valid = await v$.value.$validate();
-  if (!valid) {
-    alert("입력한 정보를 다시 확인해주세요.")
-    return;
-  }
-  
-  // DTO 형식에 맞게 payload 구성
-  const payload = {
-    userLoginId : loginId.value,
-    userPw: password.value,
-    userName: name.value,
-    userNickname: nickname.value,
-    userEmail: email.value,
-    userPhone: phone.value,
-    userBirthDate: birth.value,
-  };
-
-  // 콘솔창에 출력해보기
-  console.log("Signup Info: ", payload);
-  
-  try {
-    isSubmitting.value = true;
-
-    // 회원가입 API 호출
-    await userStore.signup(payload);
-
-    alert("회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.") // 확인하기 위한 알림창. 나중에 삭제해도 됨
-    await router.push("/signin");
-  } catch (err) {
-    const msg = err?.response?.data?.message ||
-      "회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.";
-      alert(msg);
-  } finally {
-    isSubmitting.value = false;
-  }
+// 이메일 인증 완료 핸들러
+const handleEmailVerified = () => {
+  setIsEmailVerified(true);
 };
-
-
-import { ref, computed } from "vue";
-import { RouterLink, useRouter } from "vue-router";
-import ValidatedInput from "@/components/ui/ValidatedInput.vue";
-import Button from "@/components/ui/Button.vue";
-import AppLogo from "@/components/common/AppLogo.vue";
-import useVuelidate from "@vuelidate/core";
-import {
-  required,
-  email as emailValidator,
-  minLength,
-  maxLength,
-  sameAs,
-  helpers,
-} from "@vuelidate/validators";
-import { useUserStore } from "../stores/userStore";
-import { sendVerificationCodeApi, verifyCodeApi } from "@/api/emailApi";
 </script>


### PR DESCRIPTION
## PR Summary

- **Type**: feat
- **Scope**: BE, FE (email verification & post)
- **Issue**: #145/ Refs #

## Changes

### Frontend

- **포스트 카드 UI/UX 개선**
    - 카드 레이아웃 간격 및 정렬 개선

### Backend

- **회원가입 & 비밀번호 찾기 이메일 인증 로직 개선**
    - 이메일 인증 목적 분리 (`가입`, `비밀번호 찾기`)
    - 개발 모드(`dev-mode`)에서 실제 메일 발송 없이 로그 출력 유지
    - 인증 코드 발급/검증 로직 공통화

## How to Test

### 이메일 인증

- 회원가입 / 비밀번호 찾기 플로우에서 이메일 인증 요청
    - 이미 존재하는 이메일일 경우, 메세지 출력 후 버튼 비활성화
    - 나머지의 경우, 이메일 전송 → 인증번호 입력 후 인증 완료

### 포스트 카드 UI

- 게시글 목록 화면 진입
- 게시글을 길게 작성했을 때 카드 레이아웃이 깨지지 않고 정상 렌더링되는지 확인
- 모바일/데스크탑 환경에서 카드 정렬 및 간격 확인